### PR TITLE
feat: error states & resilience UI (#15)

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { AuthProviderWrapper } from "./auth-wrapper";
+import { ErrorBoundary } from "@/components/error-boundary";
+import { OfflineBanner } from "@/components/ui/offline-banner";
 
 export const metadata: Metadata = {
   title: "LaunchLens — Listing Media OS",
@@ -21,7 +23,10 @@ export default function RootLayout({
         />
       </head>
       <body className="min-h-full flex flex-col">
-        <AuthProviderWrapper>{children}</AuthProviderWrapper>
+        <ErrorBoundary>
+          <OfflineBanner />
+          <AuthProviderWrapper>{children}</AuthProviderWrapper>
+        </ErrorBoundary>
       </body>
     </html>
   );

--- a/frontend/src/app/listings/[id]/page.tsx
+++ b/frontend/src/app/listings/[id]/page.tsx
@@ -124,12 +124,32 @@ function ListingDetail() {
     );
   }
 
+  async function handleRetryPipeline() {
+    setActionLoading(true);
+    try {
+      const res = await apiClient.retryPipeline(id);
+      setListing((prev) => (prev ? { ...prev, state: res.state } : prev));
+      toast("Pipeline restarted", "success");
+    } catch (err: unknown) {
+      toast(err instanceof Error ? err.message : "Failed to retry", "error");
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
   if (!listing) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <p className="text-[var(--color-text-secondary)]">
-          {fetchError || "Listing not found."}
-        </p>
+        <div className="text-center">
+          <p className="text-[var(--color-text-secondary)] mb-4">
+            {fetchError || "Listing not found."}
+          </p>
+          {fetchError && (
+            <Button onClick={() => { setFetchError(""); setLoading(true); fetchData(); }}>
+              Retry
+            </Button>
+          )}
+        </div>
       </div>
     );
   }
@@ -248,6 +268,24 @@ function ListingDetail() {
                       Quick Download Marketing
                     </Button>
                   </>
+                )}
+                {["failed", "pipeline_timeout"].includes(listing.state) && (
+                  <div className="w-full bg-red-50 border border-red-200 rounded-xl p-5">
+                    <h4 className="text-red-800 font-semibold mb-1">Pipeline Failed</h4>
+                    <p className="text-sm text-red-600 mb-4">
+                      {listing.state === "pipeline_timeout"
+                        ? "Processing timed out. This can happen with large photo sets."
+                        : "Something went wrong while processing your listing photos."}
+                    </p>
+                    <div className="flex gap-3">
+                      <Button onClick={handleRetryPipeline} loading={actionLoading}>
+                        Retry Processing
+                      </Button>
+                      <Link href="/listings">
+                        <Button variant="secondary">Back to Listings</Button>
+                      </Link>
+                    </div>
+                  </div>
                 )}
               </div>
 

--- a/frontend/src/components/error-boundary.tsx
+++ b/frontend/src/components/error-boundary.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Component, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) return this.props.fallback;
+
+      return (
+        <div className="min-h-[400px] flex items-center justify-center">
+          <div className="text-center max-w-md px-6">
+            <div className="w-12 h-12 rounded-full bg-red-100 flex items-center justify-center mx-auto mb-4">
+              <svg className="w-6 h-6 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.268 16.5c-.77.833.192 2.5 1.732 2.5z" />
+              </svg>
+            </div>
+            <h2 className="text-lg font-semibold text-[var(--color-text)] mb-2">
+              Something went wrong
+            </h2>
+            <p className="text-sm text-[var(--color-text-secondary)] mb-4">
+              {this.state.error?.message || "An unexpected error occurred."}
+            </p>
+            <Button onClick={this.handleReset}>Try Again</Button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/listings/asset-upload-form.tsx
+++ b/frontend/src/components/listings/asset-upload-form.tsx
@@ -32,6 +32,7 @@ export function AssetUploadForm({ listingId, onUploaded }: AssetUploadFormProps)
   const [files, setFiles] = useState<FileEntry[]>([]);
   const [uploading, setUploading] = useState(false);
   const [dragOver, setDragOver] = useState(false);
+  const [quotaError, setQuotaError] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
 
   const addFiles = useCallback((newFiles: FileList | File[]) => {
@@ -172,7 +173,12 @@ export function AssetUploadForm({ listingId, onUploaded }: AssetUploadFormProps)
       setFiles([]);
       onUploaded();
     } catch (err: unknown) {
-      toast(err instanceof Error ? err.message : "Upload failed", "error");
+      const msg = err instanceof Error ? err.message : "Upload failed";
+      if (msg.includes("limit reached") || msg.includes("Upgrade")) {
+        setQuotaError(msg);
+      } else {
+        toast(msg, "error");
+      }
     } finally {
       setUploading(false);
     }
@@ -186,6 +192,18 @@ export function AssetUploadForm({ listingId, onUploaded }: AssetUploadFormProps)
       >
         Upload Photos
       </h3>
+
+      {quotaError && (
+        <div className="mb-4 bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+          <p className="text-sm text-yellow-800 font-medium">{quotaError}</p>
+          <a
+            href="/pricing"
+            className="text-sm text-[var(--color-primary)] underline mt-1 inline-block"
+          >
+            Upgrade your plan for more
+          </a>
+        </div>
+      )}
 
       {/* Drop zone */}
       <div

--- a/frontend/src/components/ui/offline-banner.tsx
+++ b/frontend/src/components/ui/offline-banner.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+
+export function OfflineBanner() {
+  const [offline, setOffline] = useState(false);
+
+  useEffect(() => {
+    const goOffline = () => setOffline(true);
+    const goOnline = () => setOffline(false);
+
+    setOffline(!navigator.onLine);
+    window.addEventListener("offline", goOffline);
+    window.addEventListener("online", goOnline);
+    return () => {
+      window.removeEventListener("offline", goOffline);
+      window.removeEventListener("online", goOnline);
+    };
+  }, []);
+
+  return (
+    <AnimatePresence>
+      {offline && (
+        <motion.div
+          initial={{ y: -40, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: -40, opacity: 0 }}
+          className="fixed top-0 left-0 right-0 z-[100] bg-yellow-500 text-white text-center py-2 text-sm font-medium shadow-md"
+        >
+          You are offline. Changes will not be saved.
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -118,6 +118,10 @@ class ApiClient {
     return this.request(`/listings/${listingId}/review`, { method: "POST" });
   }
 
+  async retryPipeline(listingId: string): Promise<{ listing_id: string; state: string }> {
+    return this.request(`/listings/${listingId}/retry`, { method: "POST" });
+  }
+
   async approveListing(listingId: string): Promise<{ listing_id: string; state: string }> {
     return this.request(`/listings/${listingId}/approve`, { method: "POST" });
   }

--- a/src/launchlens/api/listings.py
+++ b/src/launchlens/api/listings.py
@@ -472,6 +472,46 @@ async def reject_listing(
     return {"listing_id": str(listing.id), "state": listing.state.value}
 
 
+@router.post("/{listing_id}/retry")
+async def retry_pipeline(
+    listing_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Reset a failed listing and re-trigger the pipeline."""
+    listing = (await db.execute(
+        select(Listing).where(
+            Listing.id == listing_id,
+            Listing.tenant_id == current_user.tenant_id,
+        )
+    )).scalar_one_or_none()
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+
+    retryable = {ListingState.FAILED, ListingState.PIPELINE_TIMEOUT}
+    if listing.state not in retryable:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Can only retry failed listings, current state: {listing.state.value}",
+        )
+
+    listing.state = ListingState.UPLOADING
+    tenant = await db.get(Tenant, current_user.tenant_id)
+    await db.commit()
+
+    try:
+        client = get_temporal_client()
+        await client.start_pipeline(
+            listing_id=str(listing.id),
+            tenant_id=str(current_user.tenant_id),
+            plan=tenant.plan if tenant else "starter",
+        )
+    except Exception:
+        logger.exception("Pipeline retry trigger failed for listing %s", listing.id)
+
+    return {"listing_id": str(listing.id), "state": "uploading"}
+
+
 @router.get("/{listing_id}/pipeline-status")
 async def get_pipeline_status(
     listing_id: uuid.UUID,


### PR DESCRIPTION
## Summary
- ErrorBoundary component wrapping root layout
- POST /listings/{id}/retry endpoint for failed pipelines
- Pipeline failure panel with retry button
- Fetch error with retry button (not blank page)
- Offline connectivity banner
- Quota limit upgrade feedback on 403

Closes #15

https://claude.ai/code/session_01BsHYNrUsbhpxu54bA3VabB