### PR TITLE
feat: credit-based pricing system

### DIFF
--- a/alembic/versions/011_credit_system.py
+++ b/alembic/versions/011_credit_system.py
@@ -1,0 +1,108 @@
+"""credit system — accounts, transactions, addons, tenant billing fields
+
+Revision ID: 011
+Revises: 010
+Create Date: 2026-03-28
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "011"
+down_revision = "010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Credit accounts
+    op.create_table(
+        "credit_accounts",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column("tenant_id", sa.UUID(), nullable=False, unique=True),
+        sa.Column("balance", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("rollover_balance", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("rollover_cap", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("period_start", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("period_end", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("ix_credit_accounts_tenant_id", "credit_accounts", ["tenant_id"])
+
+    # Credit transactions
+    op.create_table(
+        "credit_transactions",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column("tenant_id", sa.UUID(), nullable=False),
+        sa.Column("account_id", sa.UUID(), nullable=False),
+        sa.Column("amount", sa.Integer(), nullable=False),
+        sa.Column("balance_after", sa.Integer(), nullable=False),
+        sa.Column("transaction_type", sa.String(50), nullable=False),
+        sa.Column("reference_type", sa.String(50), nullable=True),
+        sa.Column("reference_id", sa.String(255), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("metadata", JSONB(), server_default="{}"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("ix_credit_transactions_tenant_id", "credit_transactions", ["tenant_id"])
+    op.create_index("ix_credit_transactions_ref", "credit_transactions", ["reference_type", "reference_id"])
+
+    # Addon catalog
+    op.create_table(
+        "addon_catalog",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column("slug", sa.String(100), unique=True, nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("credit_cost", sa.Integer(), nullable=False),
+        sa.Column("stripe_price_id", sa.String(255), nullable=True),
+        sa.Column("is_active", sa.Boolean(), server_default="true"),
+        sa.Column("metadata", JSONB(), server_default="{}"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+    # Addon purchases
+    op.create_table(
+        "addon_purchases",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column("tenant_id", sa.UUID(), nullable=False),
+        sa.Column("listing_id", sa.UUID(), nullable=False),
+        sa.Column("addon_id", sa.UUID(), nullable=False),
+        sa.Column("credit_transaction_id", sa.UUID(), nullable=True),
+        sa.Column("status", sa.String(50), server_default="active"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.UniqueConstraint("listing_id", "addon_id"),
+    )
+    op.create_index("ix_addon_purchases_tenant_id", "addon_purchases", ["tenant_id"])
+
+    # Tenant billing columns
+    op.add_column("tenants", sa.Column("plan_tier", sa.String(50), server_default="lite"))
+    op.add_column("tenants", sa.Column("billing_model", sa.String(50), server_default="credit"))
+    op.add_column("tenants", sa.Column("included_credits", sa.Integer(), server_default="0"))
+    op.add_column("tenants", sa.Column("per_listing_credit_cost", sa.Integer(), server_default="1"))
+
+    # Listing credit cost
+    op.add_column("listings", sa.Column("credit_cost", sa.Integer(), nullable=True))
+
+    # Seed addon catalog
+    op.execute("""
+        INSERT INTO addon_catalog (id, slug, name, credit_cost, metadata) VALUES
+        (gen_random_uuid(), 'ai_video_tour', 'AI Video Tour', 1, '{"description": "AI-generated property tour video"}'),
+        (gen_random_uuid(), '3d_floorplan', '3D Floorplan', 1, '{"description": "Interactive 3D floorplan visualization"}'),
+        (gen_random_uuid(), 'social_content_pack', 'Social Content Pack', 1, '{"description": "Platform-specific social media captions and hashtags"}')
+    """)
+
+    # Set existing tenants to legacy billing model
+    op.execute("UPDATE tenants SET billing_model = 'legacy', plan_tier = plan")
+
+
+def downgrade() -> None:
+    op.drop_column("listings", "credit_cost")
+    op.drop_column("tenants", "per_listing_credit_cost")
+    op.drop_column("tenants", "included_credits")
+    op.drop_column("tenants", "billing_model")
+    op.drop_column("tenants", "plan_tier")
+    op.drop_table("addon_purchases")
+    op.drop_table("addon_catalog")
+    op.drop_table("credit_transactions")
+    op.drop_table("credit_accounts")

--- a/frontend/src/app/pricing/page.tsx
+++ b/frontend/src/app/pricing/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { Nav } from "@/components/layout/nav";
@@ -8,136 +9,270 @@ import { Button } from "@/components/ui/button";
 
 const TIERS = [
   {
-    name: "Starter",
-    price: 29,
-    recommended: false,
-    features: {
-      "Listings / month": "5",
-      "Photos / listing": "25",
-      "AI Vision (Tier 2)": false,
-      "Social Content": false,
-      "AI Video Tours": false,
-      "MLS Export": true,
-      "Marketing Export": true,
-    },
+    name: "Lite",
+    price: 19,
+    period: "mo",
+    description: "For occasional listings. Pay per listing, no commitment.",
+    includedCredits: 0,
+    perListingPrice: 19,
+    features: [
+      "Pay-as-you-go listings",
+      "MLS + marketing bundles",
+      "AI photo analysis",
+      "Branded flyers",
+    ],
+    addons: true,
   },
   {
-    name: "Pro",
-    price: 99,
+    name: "Active Agent",
+    price: 39,
+    period: "mo",
     recommended: true,
-    features: {
-      "Listings / month": "50",
-      "Photos / listing": "50",
-      "AI Vision (Tier 2)": true,
-      "Social Content": true,
-      "AI Video Tours": true,
-      "MLS Export": true,
-      "Marketing Export": true,
-    },
+    description: "For agents listing 3-5 properties/month.",
+    includedCredits: 1,
+    perListingPrice: 14,
+    features: [
+      "1 included listing credit/month",
+      "Lower per-listing price",
+      "Unused credits roll over (cap: 3)",
+      "All Lite features",
+    ],
+    addons: true,
   },
   {
-    name: "Enterprise",
-    price: 299,
-    recommended: false,
-    features: {
-      "Listings / month": "500",
-      "Photos / listing": "100",
-      "AI Vision (Tier 2)": true,
-      "Social Content": true,
-      "AI Video Tours": true,
-      "MLS Export": true,
-      "Marketing Export": true,
-    },
+    name: "Team",
+    price: 99,
+    period: "mo",
+    description: "For brokerages and teams. Pooled credits, admin features.",
+    includedCredits: 5,
+    perListingPrice: 10,
+    features: [
+      "5 pooled listing credits/month",
+      "Team member management",
+      "Volume credit pricing",
+      "Priority support",
+      "Rollover cap: 10 credits",
+    ],
+    addons: true,
   },
 ];
 
+const CREDIT_BUNDLES = [
+  { size: 5, price: 95, perCredit: 19 },
+  { size: 10, price: 140, perCredit: 14 },
+  { size: 25, price: 300, perCredit: 12 },
+  { size: 50, price: 500, perCredit: 10 },
+];
+
+const ADDONS = [
+  { name: "AI Video Tour", cost: "1 credit", description: "AI-generated property tour video" },
+  { name: "3D Floorplan", cost: "1 credit", description: "Interactive 3D floorplan visualization" },
+  { name: "Social Content Pack", cost: "1 credit", description: "Instagram + Facebook captions & hashtags" },
+];
+
 export default function PricingPage() {
+  const [listingsPerMonth, setListingsPerMonth] = useState(3);
+
+  function calculateCost(tier: typeof TIERS[number]) {
+    const listingCreditsNeeded = Math.max(0, listingsPerMonth - tier.includedCredits);
+    return tier.price + listingCreditsNeeded * tier.perListingPrice;
+  }
+
   return (
     <>
       <Nav />
-      <main className="flex-1 max-w-5xl mx-auto w-full px-4 sm:px-6 py-8 sm:py-16">
-        <div className="text-center mb-12">
-          <motion.h1
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="text-3xl sm:text-4xl font-bold text-[var(--color-text)] mb-3"
+      <main className="flex-1 max-w-6xl mx-auto w-full px-6 py-12">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="text-center mb-12"
+        >
+          <h1
+            className="text-4xl font-bold text-[var(--color-text)]"
             style={{ fontFamily: "var(--font-heading)" }}
           >
-            Listing Media OS
-          </motion.h1>
-          <motion.p
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.1 }}
-            className="text-lg text-[var(--color-text-secondary)]"
-          >
-            From raw listing media to launch-ready marketing in minutes.
-          </motion.p>
+            Pay for what you use
+          </h1>
+          <p className="text-lg text-[var(--color-text-secondary)] mt-3 max-w-2xl mx-auto">
+            Base account fee + per-listing credits. No wasted capacity in slow months.
+          </p>
+        </motion.div>
+
+        {/* Cost calculator */}
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.1 }}
+          className="mb-10"
+        >
+          <GlassCard tilt={false}>
+            <div className="flex items-center justify-center gap-4 flex-wrap">
+              <span className="text-sm text-[var(--color-text-secondary)]">I list about</span>
+              <input
+                type="range"
+                min={1}
+                max={20}
+                value={listingsPerMonth}
+                onChange={(e) => setListingsPerMonth(Number(e.target.value))}
+                className="w-40 accent-[var(--color-cta)]"
+              />
+              <span className="text-lg font-bold text-[var(--color-text)] min-w-[3ch] text-center">
+                {listingsPerMonth}
+              </span>
+              <span className="text-sm text-[var(--color-text-secondary)]">properties/month</span>
+            </div>
+          </GlassCard>
+        </motion.div>
+
+        {/* Plan cards */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-16">
+          {TIERS.map((tier, i) => {
+            const monthlyCost = calculateCost(tier);
+
+            return (
+              <motion.div
+                key={tier.name}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.15 + i * 0.1 }}
+              >
+                <GlassCard
+                  tilt={false}
+                  className={`h-full flex flex-col ${
+                    tier.recommended
+                      ? "border-2 border-[var(--color-cta)] shadow-[0_0_30px_rgba(249,115,22,0.15)]"
+                      : ""
+                  }`}
+                >
+                  {tier.recommended && (
+                    <span className="text-xs font-bold text-[var(--color-cta)] uppercase tracking-wider mb-2">
+                      Most Popular
+                    </span>
+                  )}
+                  <h3
+                    className="text-xl font-bold text-[var(--color-text)]"
+                    style={{ fontFamily: "var(--font-heading)" }}
+                  >
+                    {tier.name}
+                  </h3>
+                  <div className="mt-2 mb-1">
+                    <span className="text-3xl font-bold text-[var(--color-text)]">${tier.price}</span>
+                    <span className="text-sm text-[var(--color-text-secondary)]">/{tier.period}</span>
+                  </div>
+                  <p className="text-xs text-[var(--color-text-secondary)] mb-1">
+                    + ${tier.perListingPrice}/listing credit
+                  </p>
+                  <div className="bg-[var(--color-background)] rounded-lg px-3 py-2 mb-4 text-center">
+                    <span className="text-sm font-medium text-[var(--color-text)]">
+                      ~${monthlyCost}/mo
+                    </span>
+                    <span className="text-xs text-[var(--color-text-secondary)] ml-1">
+                      at {listingsPerMonth} listings
+                    </span>
+                  </div>
+                  <p className="text-sm text-[var(--color-text-secondary)] mb-4">
+                    {tier.description}
+                  </p>
+                  <ul className="space-y-2 mb-6 flex-1">
+                    {tier.features.map((f) => (
+                      <li key={f} className="text-sm text-[var(--color-text)] flex items-start gap-2">
+                        <svg className="w-4 h-4 text-[var(--color-success)] mt-0.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                        </svg>
+                        {f}
+                      </li>
+                    ))}
+                  </ul>
+                  <Link href={`/register?plan=${tier.name.toLowerCase().replace(" ", "_")}`}>
+                    <Button variant={tier.recommended ? "primary" : "secondary"} className="w-full">
+                      Get Started
+                    </Button>
+                  </Link>
+                </GlassCard>
+              </motion.div>
+            );
+          })}
         </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {TIERS.map((tier, i) => (
-            <motion.div
-              key={tier.name}
-              initial={{ opacity: 0, y: 30 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: i * 0.1 }}
-            >
-              <GlassCard
-                tilt
-                className={`relative ${
-                  tier.recommended
-                    ? "border-[var(--color-cta)] border-2 shadow-[0_0_30px_rgba(249,115,22,0.15)]"
-                    : ""
-                }`}
-              >
-                {tier.recommended && (
-                  <span className="absolute -top-3 left-1/2 -translate-x-1/2 bg-[var(--color-cta)] text-white text-xs font-bold px-3 py-1 rounded-full">
-                    Recommended
-                  </span>
-                )}
-                <h2
-                  className="text-xl font-bold text-[var(--color-text)] mb-1"
+        {/* Annual option */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.5 }}
+          className="mb-16"
+        >
+          <GlassCard tilt={false}>
+            <div className="flex items-center justify-between flex-wrap gap-4">
+              <div>
+                <h3
+                  className="text-xl font-bold text-[var(--color-text)]"
                   style={{ fontFamily: "var(--font-heading)" }}
                 >
-                  {tier.name}
-                </h2>
-                <div className="mb-6">
-                  <span className="text-3xl font-bold text-[var(--color-text)]">
-                    ${tier.price}
-                  </span>
-                  <span className="text-sm text-[var(--color-text-secondary)]">/mo</span>
-                </div>
+                  Annual Credit Bank
+                </h3>
+                <p className="text-sm text-[var(--color-text-secondary)] mt-1">
+                  $399/year with 25 listing credits included. Best value for consistent agents.
+                </p>
+              </div>
+              <div className="text-right">
+                <span className="text-2xl font-bold text-[var(--color-text)]">$399</span>
+                <span className="text-sm text-[var(--color-text-secondary)]">/year</span>
+                <p className="text-xs text-[var(--color-success)]">Save vs monthly</p>
+              </div>
+              <Link href="/register?plan=annual">
+                <Button>Get Annual Plan</Button>
+              </Link>
+            </div>
+          </GlassCard>
+        </motion.div>
 
-                <ul className="space-y-3 mb-6">
-                  {Object.entries(tier.features).map(([feature, value]) => (
-                    <li key={feature} className="flex items-center justify-between text-sm">
-                      <span className="text-[var(--color-text-secondary)]">{feature}</span>
-                      {typeof value === "boolean" ? (
-                        value ? (
-                          <span className="text-green-500 font-bold">&#10003;</span>
-                        ) : (
-                          <span className="text-slate-300">&#x2014;</span>
-                        )
-                      ) : (
-                        <span className="font-medium text-[var(--color-text)]">{value}</span>
-                      )}
-                    </li>
-                  ))}
-                </ul>
-
-                <Link href={`/register?plan=${tier.name.toLowerCase()}`}>
-                  <Button
-                    className="w-full"
-                    variant={tier.recommended ? "primary" : "secondary"}
-                  >
-                    Get Started
-                  </Button>
-                </Link>
+        {/* Credit bundles */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.6 }}
+          className="mb-16"
+        >
+          <h2
+            className="text-2xl font-bold text-[var(--color-text)] mb-6 text-center"
+            style={{ fontFamily: "var(--font-heading)" }}
+          >
+            Credit Bundles
+          </h2>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            {CREDIT_BUNDLES.map((bundle) => (
+              <GlassCard key={bundle.size} tilt={false} className="text-center">
+                <p className="text-2xl font-bold text-[var(--color-text)]">{bundle.size}</p>
+                <p className="text-xs text-[var(--color-text-secondary)] mb-2">credits</p>
+                <p className="text-lg font-semibold text-[var(--color-text)]">${bundle.price}</p>
+                <p className="text-xs text-[var(--color-text-secondary)]">${bundle.perCredit}/credit</p>
               </GlassCard>
-            </motion.div>
-          ))}
-        </div>
+            ))}
+          </div>
+        </motion.div>
+
+        {/* Add-ons */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.7 }}
+        >
+          <h2
+            className="text-2xl font-bold text-[var(--color-text)] mb-6 text-center"
+            style={{ fontFamily: "var(--font-heading)" }}
+          >
+            Premium Add-Ons
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {ADDONS.map((addon) => (
+              <GlassCard key={addon.name} tilt={false}>
+                <h4 className="font-semibold text-[var(--color-text)]">{addon.name}</h4>
+                <p className="text-sm text-[var(--color-text-secondary)] mt-1">{addon.description}</p>
+                <p className="text-sm font-medium text-[var(--color-cta)] mt-2">{addon.cost}</p>
+              </GlassCard>
+            ))}
+          </div>
+        </motion.div>
       </main>
     </>
   );

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -8,6 +8,10 @@ import type {
   CreateListingRequest,
   CreateAssetsRequest,
   CreateAssetsResponse,
+  CreditBalance,
+  CreditTransaction,
+  CreditBundle,
+  Addon,
   VideoResponse,
   SocialCut,
   VideoUploadRequest,
@@ -236,6 +240,50 @@ class ApiClient {
       method: "POST",
       body: JSON.stringify(data),
     });
+  }
+
+  async cancelListing(listingId: string): Promise<{ listing_id: string; state: string; credits_refunded: number }> {
+    return this.request(`/listings/${listingId}/cancel`, { method: "POST" });
+  }
+
+  // Credits
+  async getCreditBalance(): Promise<CreditBalance> {
+    return this.request<CreditBalance>("/credits/balance");
+  }
+
+  async getCreditTransactions(limit = 50, offset = 0): Promise<CreditTransaction[]> {
+    return this.request<CreditTransaction[]>(`/credits/transactions?limit=${limit}&offset=${offset}`);
+  }
+
+  async getCreditPricing(): Promise<{ bundles: CreditBundle[] }> {
+    return this.request("/credits/pricing");
+  }
+
+  async purchaseCredits(bundleSize: number, successUrl: string, cancelUrl: string): Promise<{ checkout_url: string }> {
+    return this.request("/credits/purchase", {
+      method: "POST",
+      body: JSON.stringify({ bundle_size: bundleSize, success_url: successUrl, cancel_url: cancelUrl }),
+    });
+  }
+
+  // Addons
+  async getAddons(): Promise<Addon[]> {
+    return this.request<Addon[]>("/addons");
+  }
+
+  async activateAddon(listingId: string, addonSlug: string): Promise<{ id: string; addon_slug: string; status: string }> {
+    return this.request(`/listings/${listingId}/addons`, {
+      method: "POST",
+      body: JSON.stringify({ addon_slug: addonSlug }),
+    });
+  }
+
+  async getListingAddons(listingId: string): Promise<{ addon_slug: string; addon_name: string; status: string }[]> {
+    return this.request(`/listings/${listingId}/addons`);
+  }
+
+  async removeAddon(listingId: string, addonSlug: string): Promise<{ status: string; credits_returned: number }> {
+    return this.request(`/listings/${listingId}/addons/${addonSlug}`, { method: "DELETE" });
   }
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -134,8 +134,44 @@ export interface DemoViewResponse {
 
 export interface BillingStatusResponse {
   plan: string;
+  plan_tier: string;
+  billing_model: string;
+  credit_balance: number;
   stripe_customer_id: string | null;
   stripe_subscription_id: string | null;
+}
+
+export interface CreditBalance {
+  balance: number;
+  rollover_balance: number;
+  rollover_cap: number;
+  period_start: string;
+  period_end: string;
+}
+
+export interface CreditTransaction {
+  id: string;
+  amount: number;
+  balance_after: number;
+  transaction_type: string;
+  reference_type: string | null;
+  reference_id: string | null;
+  description: string | null;
+  created_at: string;
+}
+
+export interface Addon {
+  id: string;
+  slug: string;
+  name: string;
+  credit_cost: number;
+  is_active: boolean;
+}
+
+export interface CreditBundle {
+  size: number;
+  price_cents: number;
+  per_credit_cents: number;
 }
 
 export interface Invoice {

--- a/src/launchlens/api/addons.py
+++ b/src/launchlens/api/addons.py
@@ -1,0 +1,167 @@
+"""Add-on management API — catalog, per-listing activation."""
+import uuid
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from launchlens.api.deps import get_current_user
+from launchlens.api.schemas.addons import ActivateAddonRequest, AddonPurchaseResponse, AddonResponse
+from launchlens.database import get_db
+from launchlens.models.addon_catalog import AddonCatalog
+from launchlens.models.addon_purchase import AddonPurchase
+from launchlens.models.listing import Listing, ListingState
+from launchlens.models.user import User
+from launchlens.services.credits import CreditService, InsufficientCreditsError
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("", response_model=list[AddonResponse])
+async def list_addons(db: AsyncSession = Depends(get_db)):
+    result = await db.execute(
+        select(AddonCatalog).where(AddonCatalog.is_active.is_(True))
+    )
+    return result.scalars().all()
+
+
+@router.post("/listings/{listing_id}/addons", response_model=AddonPurchaseResponse)
+async def activate_addon(
+    listing_id: uuid.UUID,
+    body: ActivateAddonRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    # Verify listing ownership
+    listing = (await db.execute(
+        select(Listing).where(
+            Listing.id == listing_id,
+            Listing.tenant_id == current_user.tenant_id,
+        )
+    )).scalar_one_or_none()
+    if not listing:
+        raise HTTPException(404, "Listing not found")
+
+    # Can only add add-ons before pipeline starts generating
+    if listing.state not in {ListingState.NEW, ListingState.UPLOADING, ListingState.AWAITING_REVIEW, ListingState.IN_REVIEW}:
+        raise HTTPException(409, f"Cannot add add-ons in state: {listing.state.value}")
+
+    # Find the add-on
+    addon = (await db.execute(
+        select(AddonCatalog).where(AddonCatalog.slug == body.addon_slug, AddonCatalog.is_active.is_(True))
+    )).scalar_one_or_none()
+    if not addon:
+        raise HTTPException(404, f"Add-on not found: {body.addon_slug}")
+
+    # Check for duplicate
+    existing = (await db.execute(
+        select(AddonPurchase).where(
+            AddonPurchase.listing_id == listing_id,
+            AddonPurchase.addon_id == addon.id,
+        )
+    )).scalar_one_or_none()
+    if existing:
+        raise HTTPException(409, f"Add-on already activated for this listing")
+
+    # Deduct credits
+    credit_svc = CreditService()
+    try:
+        txn = await credit_svc.deduct_credits(
+            db, current_user.tenant_id, addon.credit_cost,
+            transaction_type="addon_debit",
+            reference_type="addon",
+            reference_id=f"{listing_id}:{addon.slug}",
+            description=f"{addon.name} for listing {listing_id}",
+        )
+    except InsufficientCreditsError:
+        raise HTTPException(402, f"Insufficient credits. Need {addon.credit_cost}, check your balance.")
+
+    purchase = AddonPurchase(
+        tenant_id=current_user.tenant_id,
+        listing_id=listing_id,
+        addon_id=addon.id,
+        credit_transaction_id=txn.id,
+    )
+    db.add(purchase)
+    await db.commit()
+
+    return AddonPurchaseResponse(
+        id=purchase.id,
+        addon_id=addon.id,
+        addon_slug=addon.slug,
+        addon_name=addon.name,
+        status=purchase.status,
+        created_at=purchase.created_at,
+    )
+
+
+@router.get("/listings/{listing_id}/addons", response_model=list[AddonPurchaseResponse])
+async def list_listing_addons(
+    listing_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(
+        select(AddonPurchase, AddonCatalog)
+        .join(AddonCatalog, AddonPurchase.addon_id == AddonCatalog.id)
+        .where(
+            AddonPurchase.listing_id == listing_id,
+            AddonPurchase.tenant_id == current_user.tenant_id,
+        )
+    )
+    return [
+        AddonPurchaseResponse(
+            id=purchase.id,
+            addon_id=addon.id,
+            addon_slug=addon.slug,
+            addon_name=addon.name,
+            status=purchase.status,
+            created_at=purchase.created_at,
+        )
+        for purchase, addon in result.all()
+    ]
+
+
+@router.delete("/listings/{listing_id}/addons/{addon_slug}")
+async def remove_addon(
+    listing_id: uuid.UUID,
+    addon_slug: str,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Remove an add-on and refund credits if pipeline hasn't started."""
+    purchase = (await db.execute(
+        select(AddonPurchase, AddonCatalog)
+        .join(AddonCatalog, AddonPurchase.addon_id == AddonCatalog.id)
+        .where(
+            AddonPurchase.listing_id == listing_id,
+            AddonPurchase.tenant_id == current_user.tenant_id,
+            AddonCatalog.slug == addon_slug,
+        )
+    )).one_or_none()
+
+    if not purchase:
+        raise HTTPException(404, "Add-on not found on this listing")
+
+    addon_purchase, addon = purchase
+
+    listing = await db.get(Listing, listing_id)
+    if listing and listing.state in {ListingState.NEW, ListingState.UPLOADING, ListingState.AWAITING_REVIEW}:
+        # Refund credits
+        credit_svc = CreditService()
+        await credit_svc.add_credits(
+            db, current_user.tenant_id, addon.credit_cost,
+            transaction_type="refund",
+            reference_type="addon",
+            reference_id=f"{listing_id}:{addon_slug}:refund",
+            description=f"Refund: {addon.name} removed from listing {listing_id}",
+        )
+        addon_purchase.status = "refunded"
+    else:
+        raise HTTPException(409, "Cannot remove add-on after pipeline has started processing")
+
+    await db.commit()
+    return {"status": "refunded", "credits_returned": addon.credit_cost}

--- a/src/launchlens/api/credits.py
+++ b/src/launchlens/api/credits.py
@@ -1,0 +1,108 @@
+"""Credit system API — balance, transactions, purchases."""
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from launchlens.api.deps import get_current_user
+from launchlens.api.schemas.credits import (
+    CreditBalanceResponse,
+    CreditPricingResponse,
+    CreditPurchaseRequest,
+    CreditPurchaseResponse,
+    CreditTransactionResponse,
+)
+from launchlens.database import get_db
+from launchlens.models.user import User
+from launchlens.services.billing import BillingService
+from launchlens.services.credits import CreditService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+CREDIT_BUNDLES = [
+    {"size": 5, "price_cents": 9500, "per_credit_cents": 1900},
+    {"size": 10, "price_cents": 14000, "per_credit_cents": 1400},
+    {"size": 25, "price_cents": 30000, "per_credit_cents": 1200},
+    {"size": 50, "price_cents": 50000, "per_credit_cents": 1000},
+]
+
+BUNDLE_SIZE_TO_STRIPE_SETTING = {
+    5: "stripe_price_credit_bundle_5",
+    10: "stripe_price_credit_bundle_10",
+    25: "stripe_price_credit_bundle_25",
+    50: "stripe_price_credit_bundle_50",
+}
+
+
+@router.get("/balance", response_model=CreditBalanceResponse)
+async def get_credit_balance(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    svc = CreditService()
+    try:
+        balance = await svc.get_balance(db, current_user.tenant_id)
+    except ValueError:
+        # No credit account yet — create one
+        await svc.ensure_account(db, current_user.tenant_id)
+        await db.commit()
+        balance = await svc.get_balance(db, current_user.tenant_id)
+    return balance
+
+
+@router.get("/transactions", response_model=list[CreditTransactionResponse])
+async def get_credit_transactions(
+    limit: int = 50,
+    offset: int = 0,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    svc = CreditService()
+    return await svc.get_transactions(db, current_user.tenant_id, limit=limit, offset=offset)
+
+
+@router.get("/pricing", response_model=CreditPricingResponse)
+async def get_credit_pricing():
+    return CreditPricingResponse(bundles=CREDIT_BUNDLES)
+
+
+@router.post("/purchase", response_model=CreditPurchaseResponse)
+async def purchase_credits(
+    body: CreditPurchaseRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    if body.bundle_size not in BUNDLE_SIZE_TO_STRIPE_SETTING:
+        raise HTTPException(400, f"Invalid bundle size. Choose from: {list(BUNDLE_SIZE_TO_STRIPE_SETTING.keys())}")
+
+    from launchlens.config import settings
+    from launchlens.models.tenant import Tenant
+
+    tenant = await db.get(Tenant, current_user.tenant_id)
+    if not tenant:
+        raise HTTPException(404, "Tenant not found")
+
+    setting_name = BUNDLE_SIZE_TO_STRIPE_SETTING[body.bundle_size]
+    price_id = getattr(settings, setting_name, "")
+    if not price_id:
+        raise HTTPException(501, "Credit bundle pricing not configured")
+
+    billing_svc = BillingService()
+    if not tenant.stripe_customer_id:
+        tenant.stripe_customer_id = billing_svc.create_customer(
+            email=current_user.email, name=tenant.name, tenant_id=str(tenant.id),
+        )
+        await db.commit()
+
+    import stripe
+    session = stripe.checkout.Session.create(
+        customer=tenant.stripe_customer_id,
+        line_items=[{"price": price_id, "quantity": 1}],
+        mode="payment",
+        success_url=body.success_url,
+        cancel_url=body.cancel_url,
+        metadata={"tenant_id": str(tenant.id), "bundle_size": str(body.bundle_size), "type": "credit_bundle"},
+    )
+    return CreditPurchaseResponse(checkout_url=session.url)

--- a/src/launchlens/api/listings.py
+++ b/src/launchlens/api/listings.py
@@ -48,26 +48,9 @@ async def create_listing(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    # Check monthly listing quota
     tenant = await db.get(Tenant, current_user.tenant_id)
     if not tenant:
         raise HTTPException(status_code=404, detail="Tenant not found")
-
-    now = datetime.now(timezone.utc)
-    month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-    count_result = await db.execute(
-        select(func.count(Listing.id)).where(
-            Listing.tenant_id == current_user.tenant_id,
-            Listing.created_at >= month_start,
-        )
-    )
-    current_count = count_result.scalar() or 0
-
-    if not check_listing_quota(tenant.plan, current_count):
-        raise HTTPException(
-            status_code=403,
-            detail=f"Monthly listing limit reached ({current_count}). Upgrade your plan for more.",
-        )
 
     listing = Listing(
         id=uuid.uuid4(),
@@ -76,6 +59,43 @@ async def create_listing(
         metadata_=body.metadata,
         state=ListingState.NEW,
     )
+
+    if tenant.billing_model == "credit":
+        # Credit-based billing: deduct credits
+        from launchlens.services.credits import CreditService, InsufficientCreditsError
+        credit_svc = CreditService()
+        cost = tenant.per_listing_credit_cost
+        try:
+            await credit_svc.deduct_credits(
+                db, tenant.id, cost,
+                transaction_type="listing_debit",
+                reference_type="listing",
+                reference_id=str(listing.id),
+                description=f"Listing at {body.address.get('street', 'new listing')}",
+            )
+            listing.credit_cost = cost
+        except InsufficientCreditsError:
+            raise HTTPException(
+                status_code=402,
+                detail=f"Insufficient credits. Need {cost} credit(s). Purchase more to continue.",
+            )
+    else:
+        # Legacy billing: monthly quota check
+        now = datetime.now(timezone.utc)
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        count_result = await db.execute(
+            select(func.count(Listing.id)).where(
+                Listing.tenant_id == current_user.tenant_id,
+                Listing.created_at >= month_start,
+            )
+        )
+        current_count = count_result.scalar() or 0
+        if not check_listing_quota(tenant.plan, current_count):
+            raise HTTPException(
+                status_code=403,
+                detail=f"Monthly listing limit reached ({current_count}). Upgrade your plan for more.",
+            )
+
     db.add(listing)
     await db.commit()
     await db.refresh(listing)
@@ -516,6 +536,41 @@ async def retry_pipeline(
         logger.exception("Pipeline retry trigger failed for listing %s", listing.id)
 
     return {"listing_id": str(listing.id), "state": "uploading"}
+
+
+@router.post("/{listing_id}/cancel")
+async def cancel_listing(
+    listing_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Cancel a listing and refund credits if using credit billing."""
+    listing = (await db.execute(
+        select(Listing).where(
+            Listing.id == listing_id,
+            Listing.tenant_id == current_user.tenant_id,
+        )
+    )).scalar_one_or_none()
+    if not listing:
+        raise HTTPException(status_code=404, detail="Listing not found")
+
+    cancellable = {ListingState.NEW, ListingState.UPLOADING, ListingState.FAILED, ListingState.PIPELINE_TIMEOUT}
+    if listing.state not in cancellable:
+        raise HTTPException(409, f"Cannot cancel: listing is {listing.state.value}")
+
+    credits_refunded = 0
+    tenant = await db.get(Tenant, current_user.tenant_id)
+    if tenant and tenant.billing_model == "credit" and listing.credit_cost:
+        from launchlens.services.credits import CreditService
+        credit_svc = CreditService()
+        txn = await credit_svc.refund_credits(db, current_user.tenant_id, str(listing_id))
+        if txn:
+            credits_refunded = txn.amount
+
+    listing.state = ListingState.FAILED  # reuse FAILED state for cancelled
+    await db.commit()
+
+    return {"listing_id": str(listing.id), "state": "cancelled", "credits_refunded": credits_refunded}
 
 
 @router.get("/{listing_id}/pipeline-status")

--- a/src/launchlens/api/schemas/addons.py
+++ b/src/launchlens/api/schemas/addons.py
@@ -1,0 +1,27 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class AddonResponse(BaseModel):
+    id: uuid.UUID
+    slug: str
+    name: str
+    credit_cost: int
+    is_active: bool
+
+    model_config = {"from_attributes": True}
+
+
+class AddonPurchaseResponse(BaseModel):
+    id: uuid.UUID
+    addon_id: uuid.UUID
+    addon_slug: str
+    addon_name: str
+    status: str
+    created_at: datetime
+
+
+class ActivateAddonRequest(BaseModel):
+    addon_slug: str

--- a/src/launchlens/api/schemas/credits.py
+++ b/src/launchlens/api/schemas/credits.py
@@ -1,0 +1,39 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class CreditBalanceResponse(BaseModel):
+    balance: int
+    rollover_balance: int
+    rollover_cap: int
+    period_start: datetime
+    period_end: datetime
+
+
+class CreditTransactionResponse(BaseModel):
+    id: uuid.UUID
+    amount: int
+    balance_after: int
+    transaction_type: str
+    reference_type: str | None
+    reference_id: str | None
+    description: str | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class CreditPurchaseRequest(BaseModel):
+    bundle_size: int  # 5, 10, 25, or 50
+    success_url: str
+    cancel_url: str
+
+
+class CreditPurchaseResponse(BaseModel):
+    checkout_url: str
+
+
+class CreditPricingResponse(BaseModel):
+    bundles: list[dict]  # [{size: 5, price_cents: 9500, per_credit_cents: 1900}, ...]

--- a/src/launchlens/config.py
+++ b/src/launchlens/config.py
@@ -64,6 +64,18 @@ class Settings(BaseSettings):
     # Canva
     canva_api_key: str = ""
 
+    # Credit bundles (Stripe price IDs for one-time purchases)
+    stripe_price_credit_bundle_5: str = ""
+    stripe_price_credit_bundle_10: str = ""
+    stripe_price_credit_bundle_25: str = ""
+    stripe_price_credit_bundle_50: str = ""
+
+    # New tier pricing (Stripe price IDs)
+    stripe_price_lite: str = ""
+    stripe_price_active_agent: str = ""
+    stripe_price_team: str = ""
+    stripe_price_annual: str = ""
+
     # Email / Notifications
     smtp_host: str = ""
     smtp_port: int = 587

--- a/src/launchlens/main.py
+++ b/src/launchlens/main.py
@@ -4,6 +4,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from launchlens.api import (
+    addons,
     admin,
     analytics,
     assets,
@@ -11,6 +12,7 @@ from launchlens.api import (
     billing,
     brand_kit,
     bulk,
+    credits,
     demo,
     health,
     listings,
@@ -67,6 +69,8 @@ def create_app() -> FastAPI:
     app.include_router(analytics.router, prefix="/analytics", tags=["analytics"])
     app.include_router(bulk.router, prefix="/bulk", tags=["bulk"])
     app.include_router(brand_kit.router, prefix="/brand-kit", tags=["brand-kit"])
+    app.include_router(credits.router, prefix="/credits", tags=["credits"])
+    app.include_router(addons.router, tags=["addons"])
     app.include_router(sse.router, tags=["sse"])
     app.include_router(health.router)
 

--- a/src/launchlens/models/__init__.py
+++ b/src/launchlens/models/__init__.py
@@ -18,3 +18,7 @@ from .video_asset import VideoAsset                          # noqa
 from .dollhouse_scene import DollhouseScene                  # noqa
 from .api_key import APIKey                                  # noqa
 from .notification_preference import NotificationPreference  # noqa
+from .credit_account import CreditAccount                    # noqa
+from .credit_transaction import CreditTransaction            # noqa
+from .addon_catalog import AddonCatalog                      # noqa
+from .addon_purchase import AddonPurchase                    # noqa

--- a/src/launchlens/models/addon_catalog.py
+++ b/src/launchlens/models/addon_catalog.py
@@ -1,0 +1,20 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import UUID, Boolean, DateTime, Integer, String, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from launchlens.database import Base
+
+
+class AddonCatalog(Base):
+    __tablename__ = "addon_catalog"
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    slug: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    credit_cost: Mapped[int] = mapped_column(Integer, nullable=False)
+    stripe_price_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    metadata_: Mapped[dict] = mapped_column(JSONB, name="metadata", default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/src/launchlens/models/addon_purchase.py
+++ b/src/launchlens/models/addon_purchase.py
@@ -1,0 +1,19 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import UUID, DateTime, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from launchlens.database import Base
+
+
+class AddonPurchase(Base):
+    __tablename__ = "addon_purchases"
+    __table_args__ = (UniqueConstraint("listing_id", "addon_id"),)
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    listing_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    addon_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    credit_transaction_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    status: Mapped[str] = mapped_column(String(50), default="active")  # active, refunded, completed
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/src/launchlens/models/credit_account.py
+++ b/src/launchlens/models/credit_account.py
@@ -1,0 +1,21 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import UUID, DateTime, Integer, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from launchlens.database import Base
+
+
+class CreditAccount(Base):
+    __tablename__ = "credit_accounts"
+    __table_args__ = (UniqueConstraint("tenant_id"),)
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    balance: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    rollover_balance: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    rollover_cap: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    period_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    period_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())

--- a/src/launchlens/models/credit_transaction.py
+++ b/src/launchlens/models/credit_transaction.py
@@ -1,0 +1,25 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import UUID, DateTime, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from launchlens.database import Base
+
+
+class CreditTransaction(Base):
+    __tablename__ = "credit_transactions"
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    account_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    amount: Mapped[int] = mapped_column(Integer, nullable=False)  # positive = credit, negative = debit
+    balance_after: Mapped[int] = mapped_column(Integer, nullable=False)
+    transaction_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    # Types: plan_grant, purchase, listing_debit, addon_debit, refund, rollover, expiry, admin_adjustment
+    reference_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    # Reference types: listing, addon, stripe_invoice
+    reference_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    metadata_: Mapped[dict] = mapped_column(JSONB, name="metadata", default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/src/launchlens/models/listing.py
+++ b/src/launchlens/models/listing.py
@@ -2,7 +2,7 @@ import enum
 import uuid
 from datetime import datetime
 
-from sqlalchemy import UUID, Boolean, DateTime, String, func
+from sqlalchemy import UUID, Boolean, DateTime, Integer, String, func
 from sqlalchemy import Enum as SAEnum
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
@@ -41,5 +41,6 @@ class Listing(TenantScopedModel):
     )
     mls_bundle_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
     marketing_bundle_path: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    credit_cost: Mapped[int | None] = mapped_column(Integer, nullable=True)
     is_demo: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
     demo_expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/src/launchlens/models/tenant.py
+++ b/src/launchlens/models/tenant.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import UUID, DateTime, String, func
+from sqlalchemy import UUID, DateTime, Integer, String, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from launchlens.database import Base
@@ -12,6 +12,10 @@ class Tenant(Base):
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     plan: Mapped[str] = mapped_column(String(50), default="starter")
+    plan_tier: Mapped[str] = mapped_column(String(50), default="lite")
+    billing_model: Mapped[str] = mapped_column(String(50), default="credit")
+    included_credits: Mapped[int] = mapped_column(Integer, default=0)
+    per_listing_credit_cost: Mapped[int] = mapped_column(Integer, default=1)
     stripe_customer_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     stripe_subscription_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     webhook_url: Mapped[str | None] = mapped_column(String(500), nullable=True)

--- a/src/launchlens/services/credits.py
+++ b/src/launchlens/services/credits.py
@@ -1,0 +1,246 @@
+"""Credit system service — atomic deduction, refunds, rollover, balance queries."""
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from launchlens.models.credit_account import CreditAccount
+from launchlens.models.credit_transaction import CreditTransaction
+
+
+class InsufficientCreditsError(Exception):
+    pass
+
+
+@dataclass
+class CreditBalance:
+    balance: int
+    rollover_balance: int
+    rollover_cap: int
+    period_start: datetime
+    period_end: datetime
+
+
+class CreditService:
+
+    async def get_balance(self, session: AsyncSession, tenant_id: uuid.UUID) -> CreditBalance:
+        account = await self._get_account(session, tenant_id)
+        return CreditBalance(
+            balance=account.balance,
+            rollover_balance=account.rollover_balance,
+            rollover_cap=account.rollover_cap,
+            period_start=account.period_start,
+            period_end=account.period_end,
+        )
+
+    async def has_sufficient_credits(self, session: AsyncSession, tenant_id: uuid.UUID, amount: int) -> bool:
+        account = await self._get_account(session, tenant_id)
+        return account.balance >= amount
+
+    async def deduct_credits(
+        self,
+        session: AsyncSession,
+        tenant_id: uuid.UUID,
+        amount: int,
+        transaction_type: str,
+        reference_type: str,
+        reference_id: str,
+        description: str = "",
+    ) -> CreditTransaction:
+        """Atomically deduct credits. Uses SELECT FOR UPDATE to prevent races."""
+        # Idempotency: check if this deduction already happened
+        existing = await session.execute(
+            select(CreditTransaction).where(
+                CreditTransaction.reference_type == reference_type,
+                CreditTransaction.reference_id == reference_id,
+                CreditTransaction.transaction_type == transaction_type,
+                CreditTransaction.amount < 0,
+            ).limit(1)
+        )
+        if existing.scalar_one_or_none():
+            raise ValueError(f"Credits already deducted for {reference_type}:{reference_id}")
+
+        account = await self._get_account_for_update(session, tenant_id)
+
+        if account.balance < amount:
+            raise InsufficientCreditsError(
+                f"Need {amount} credits, have {account.balance}"
+            )
+
+        account.balance -= amount
+        txn = CreditTransaction(
+            tenant_id=tenant_id,
+            account_id=account.id,
+            amount=-amount,
+            balance_after=account.balance,
+            transaction_type=transaction_type,
+            reference_type=reference_type,
+            reference_id=reference_id,
+            description=description,
+        )
+        session.add(txn)
+        return txn
+
+    async def add_credits(
+        self,
+        session: AsyncSession,
+        tenant_id: uuid.UUID,
+        amount: int,
+        transaction_type: str,
+        reference_type: str | None = None,
+        reference_id: str | None = None,
+        description: str = "",
+    ) -> CreditTransaction:
+        """Add credits to a tenant's balance."""
+        # Idempotency for purchases/grants
+        if reference_id:
+            existing = await session.execute(
+                select(CreditTransaction).where(
+                    CreditTransaction.reference_id == reference_id,
+                    CreditTransaction.transaction_type == transaction_type,
+                    CreditTransaction.amount > 0,
+                ).limit(1)
+            )
+            if existing.scalar_one_or_none():
+                raise ValueError(f"Credits already granted for {reference_id}")
+
+        account = await self._get_account_for_update(session, tenant_id)
+
+        account.balance += amount
+        txn = CreditTransaction(
+            tenant_id=tenant_id,
+            account_id=account.id,
+            amount=amount,
+            balance_after=account.balance,
+            transaction_type=transaction_type,
+            reference_type=reference_type,
+            reference_id=reference_id,
+            description=description,
+        )
+        session.add(txn)
+        return txn
+
+    async def refund_credits(
+        self,
+        session: AsyncSession,
+        tenant_id: uuid.UUID,
+        listing_id: str,
+    ) -> CreditTransaction | None:
+        """Refund credits for a listing. Returns None if no deduction found."""
+        # Find original deduction
+        result = await session.execute(
+            select(CreditTransaction).where(
+                CreditTransaction.tenant_id == tenant_id,
+                CreditTransaction.reference_type == "listing",
+                CreditTransaction.reference_id == listing_id,
+                CreditTransaction.transaction_type == "listing_debit",
+            ).limit(1)
+        )
+        original = result.scalar_one_or_none()
+        if not original:
+            return None
+
+        refund_amount = abs(original.amount)
+        return await self.add_credits(
+            session, tenant_id, refund_amount,
+            transaction_type="refund",
+            reference_type="listing",
+            reference_id=listing_id,
+            description=f"Refund for cancelled listing {listing_id}",
+        )
+
+    async def process_period_renewal(
+        self,
+        session: AsyncSession,
+        tenant_id: uuid.UUID,
+        included_credits: int,
+    ) -> None:
+        """Handle billing period rollover: cap old credits, grant new ones."""
+        account = await self._get_account_for_update(session, tenant_id)
+
+        # Expire credits above rollover cap
+        rollover_amount = min(account.balance, account.rollover_cap)
+        expired = account.balance - rollover_amount
+
+        if expired > 0:
+            session.add(CreditTransaction(
+                tenant_id=tenant_id,
+                account_id=account.id,
+                amount=-expired,
+                balance_after=rollover_amount,
+                transaction_type="expiry",
+                description=f"Expired {expired} credits at period end",
+            ))
+
+        # Grant new included credits
+        new_balance = rollover_amount + included_credits
+        if included_credits > 0:
+            session.add(CreditTransaction(
+                tenant_id=tenant_id,
+                account_id=account.id,
+                amount=included_credits,
+                balance_after=new_balance,
+                transaction_type="plan_grant",
+                description=f"Monthly grant of {included_credits} credits",
+            ))
+
+        account.balance = new_balance
+        account.rollover_balance = rollover_amount
+        now = datetime.now(timezone.utc)
+        account.period_start = now
+        # Approximate next period (Stripe handles exact dates)
+        from datetime import timedelta
+        account.period_end = now + timedelta(days=30)
+
+    async def get_transactions(
+        self,
+        session: AsyncSession,
+        tenant_id: uuid.UUID,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[CreditTransaction]:
+        result = await session.execute(
+            select(CreditTransaction)
+            .where(CreditTransaction.tenant_id == tenant_id)
+            .order_by(CreditTransaction.created_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        return list(result.scalars().all())
+
+    async def ensure_account(self, session: AsyncSession, tenant_id: uuid.UUID, rollover_cap: int = 0) -> CreditAccount:
+        """Get or create a credit account for a tenant."""
+        account = (await session.execute(
+            select(CreditAccount).where(CreditAccount.tenant_id == tenant_id)
+        )).scalar_one_or_none()
+        if not account:
+            account = CreditAccount(
+                tenant_id=tenant_id,
+                balance=0,
+                rollover_cap=rollover_cap,
+            )
+            session.add(account)
+            await session.flush()
+        return account
+
+    async def _get_account(self, session: AsyncSession, tenant_id: uuid.UUID) -> CreditAccount:
+        result = await session.execute(
+            select(CreditAccount).where(CreditAccount.tenant_id == tenant_id)
+        )
+        account = result.scalar_one_or_none()
+        if not account:
+            raise ValueError(f"No credit account for tenant {tenant_id}")
+        return account
+
+    async def _get_account_for_update(self, session: AsyncSession, tenant_id: uuid.UUID) -> CreditAccount:
+        result = await session.execute(
+            select(CreditAccount)
+            .where(CreditAccount.tenant_id == tenant_id)
+            .with_for_update()
+        )
+        account = result.scalar_one_or_none()
+        if not account:
+            raise ValueError(f"No credit account for tenant {tenant_id}")
+        return account

--- a/src/launchlens/workflows/listing_pipeline.py
+++ b/src/launchlens/workflows/listing_pipeline.py
@@ -30,6 +30,8 @@ class ListingPipelineInput:
     listing_id: str
     tenant_id: str
     plan: str = "starter"
+    billing_model: str = "legacy"
+    enabled_addons: list[str] | None = None
 
 
 _DEFAULT_RETRY = RetryPolicy(maximum_attempts=3)
@@ -93,20 +95,29 @@ class ListingPipeline:
         )
 
         # Start video generation in parallel with human review
-        video_task = workflow.execute_activity(
-            run_video, ctx,
-            start_to_close_timeout=timedelta(minutes=30),  # Kling generation takes time
-            retry_policy=_DEFAULT_RETRY,
-        )
+        # For credit users, only run if video add-on is enabled
+        addons = input.enabled_addons or []
+        run_video_step = True
+        if input.billing_model == "credit" and "ai_video_tour" not in addons:
+            run_video_step = False
+
+        video_task = None
+        if run_video_step:
+            video_task = workflow.execute_activity(
+                run_video, ctx,
+                start_to_close_timeout=timedelta(minutes=30),
+                retry_policy=_DEFAULT_RETRY,
+            )
 
         # Wait for human review (listing is now AWAITING_REVIEW)
         await workflow.wait_condition(lambda: self._review_completed)
 
         # Collect video result (may already be done) — don't block pipeline on failure
-        try:
-            await video_task
-        except Exception:
-            pass  # Video is optional; pipeline continues without it
+        if video_task:
+            try:
+                await video_task
+            except Exception:
+                pass  # Video is optional; pipeline continues without it
 
         # Phase 2: Post-approval pipeline
         # Step 1: Content (dual-tone)
@@ -124,7 +135,12 @@ class ListingPipeline:
                 retry_policy=_DEFAULT_RETRY,
             )
         ]
-        if input.plan in ("pro", "enterprise"):
+        # Social content: plan-gated for legacy, addon-gated for credit users
+        run_social = (
+            (input.billing_model == "credit" and "social_content_pack" in addons)
+            or (input.billing_model != "credit" and input.plan in ("pro", "enterprise"))
+        )
+        if run_social:
             parallel_tasks.append(
                 workflow.execute_activity(
                     run_social_content, ctx,


### PR DESCRIPTION
## Summary
Credit-based pricing system replacing fixed monthly listing caps with usage-based billing.

- **4 new models:** CreditAccount, CreditTransaction, AddonCatalog, AddonPurchase
- **CreditService:** atomic deduction (SELECT FOR UPDATE), refunds, rollover, idempotency
- **New API routers:** `/credits` (balance, transactions, purchase) + `/addons` (catalog, activate, remove)
- **Listing creation:** branches on `billing_model` — credit deduction vs legacy quota
- **Pipeline gating:** addon-based for credit users, plan-based for legacy
- **Pricing page redesign:** 3 tiers + annual + bundles + add-ons + interactive cost calculator
- **Dual-mode migration:** existing tenants keep `billing_model=legacy`, new signups get `credit`

## New Tiers
| Tier | Base | Included Credits | Per-Listing |
|------|------|-----------------|-------------|
| Lite | $19/mo | 0 | $19/credit |
| Active Agent | $39/mo | 1 | $14/credit |
| Team | $99/mo | 5 | $10/credit |
| Annual | $399/yr | 25 | included |

## Test plan
- [ ] Create listing with credit billing → credit deducted
- [ ] Insufficient credits → 402 error
- [ ] Cancel listing → credits refunded
- [ ] Activate add-on → addon credit deducted, pipeline runs addon agent
- [ ] Legacy tenant → unchanged behavior
- [ ] Pricing page renders with calculator

https://claude.ai/code/session_01BsHYNrUsbhpxu54bA3VabB