### PR TITLE
Add listing thumbnail photos to cards

### DIFF
--- a/frontend/src/components/listings/listing-card.tsx
+++ b/frontend/src/components/listings/listing-card.tsx
@@ -35,12 +35,20 @@ export function ListingCard({ listing, onDeleted }: ListingCardProps) {
     >
       {/* Photo Thumbnail */}
       <div className="relative aspect-[4/3] bg-gradient-to-br from-slate-200 to-slate-100 overflow-hidden">
-        <div className="absolute inset-0 flex items-center justify-center">
-          <svg className="w-10 h-10 text-slate-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" />
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 22V12h6v10" />
-          </svg>
-        </div>
+        {listing.thumbnail_url ? (
+          <img
+            src={listing.thumbnail_url}
+            alt={address.street || "Property photo"}
+            className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-500"
+          />
+        ) : (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <svg className="w-10 h-10 text-slate-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 22V12h6v10" />
+            </svg>
+          </div>
+        )}
         <div className="absolute top-3 left-3">
           <Badge state={state} />
         </div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -31,6 +31,7 @@ export interface ListingResponse {
     price?: number;
   };
   state: string;
+  thumbnail_url: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/src/listingjet/api/listings_core.py
+++ b/src/listingjet/api/listings_core.py
@@ -119,7 +119,55 @@ async def list_listings(
     query = base_query.order_by(Listing.created_at.desc()).limit(page_size).offset(offset)
     result = await db.execute(query)
     listings = result.scalars().all()
-    items = [ListingResponse.from_orm_listing(listing) for listing in listings]
+
+    # Fetch thumbnails: hero photo (PackageSelection pos 0) or first uploaded asset
+    listing_ids = [item.id for item in listings]
+    thumbnail_map: dict[uuid.UUID, str | None] = {}
+    if listing_ids:
+        try:
+            from sqlalchemy import and_
+
+            from listingjet.services.storage import get_storage
+            storage = get_storage()
+
+            # Hero photos from PackageSelection
+            hero_rows = (await db.execute(
+                select(PackageSelection.listing_id, Asset.file_path)
+                .join(Asset, PackageSelection.asset_id == Asset.id)
+                .where(PackageSelection.listing_id.in_(listing_ids), PackageSelection.position == 0)
+            )).all()
+            for lid, fpath in hero_rows:
+                try:
+                    thumbnail_map[lid] = storage.presigned_url(fpath, expires_in=3600)
+                except Exception:
+                    pass
+
+            # Fallback: first asset for listings without hero
+            missing = [lid for lid in listing_ids if lid not in thumbnail_map]
+            if missing:
+                subq = (
+                    select(Asset.listing_id, func.min(Asset.created_at).label("min_created"))
+                    .where(Asset.listing_id.in_(missing))
+                    .group_by(Asset.listing_id)
+                    .subquery()
+                )
+                first_assets = (await db.execute(
+                    select(Asset.listing_id, Asset.file_path)
+                    .join(subq, and_(Asset.listing_id == subq.c.listing_id, Asset.created_at == subq.c.min_created))
+                )).all()
+                for lid, fpath in first_assets:
+                    if lid not in thumbnail_map:
+                        try:
+                            thumbnail_map[lid] = storage.presigned_url(fpath, expires_in=3600)
+                        except Exception:
+                            pass
+        except Exception:
+            logger.exception("thumbnail_fetch_failed")
+
+    items = [
+        ListingResponse.from_orm_listing(listing, thumbnail_url=thumbnail_map.get(listing.id))
+        for listing in listings
+    ]
 
     return {
         "items": items,

--- a/src/listingjet/api/schemas/listings.py
+++ b/src/listingjet/api/schemas/listings.py
@@ -68,6 +68,7 @@ class ListingResponse(BaseModel):
     address: dict
     metadata: dict
     state: str
+    thumbnail_url: str | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -89,13 +90,14 @@ class ListingResponse(BaseModel):
     }
 
     @classmethod
-    def from_orm_listing(cls, listing):
+    def from_orm_listing(cls, listing, thumbnail_url: str | None = None):
         return cls(
             id=listing.id,
             tenant_id=listing.tenant_id,
             address=listing.address,
             metadata=listing.metadata_,
             state=listing.state.value if hasattr(listing.state, 'value') else listing.state,
+            thumbnail_url=thumbnail_url,
             created_at=listing.created_at,
             updated_at=listing.updated_at,
         )


### PR DESCRIPTION
## Summary

Adds listing photo thumbnails to dashboard and listing cards. Clean apply on current master (no conflicts).

**Backend:** `ListingResponse` now includes `thumbnail_url` — the list endpoint fetches the hero photo (PackageSelection position 0) or falls back to the first uploaded asset. Uses presigned S3 URLs with graceful degradation.

**Frontend:** `ListingCard` renders the actual property photo with cover-fit and hover zoom when available, falls back to the placeholder house icon.

## Test plan
- [ ] Listings with uploaded photos show thumbnails on dashboard
- [ ] Listings without photos show placeholder icon
- [ ] No errors in console for listings with/without photos

https://claude.ai/code/session_01636aiyTCJyU3yJv2DUmPRN