### PR TITLE
feat: add ScoringEvent logging for XGBoost training data pipeline

### DIFF
--- a/alembic/versions/037_scoring_events.py
+++ b/alembic/versions/037_scoring_events.py
@@ -1,0 +1,44 @@
+"""Add scoring_events table for XGBoost training data.
+
+Revision ID: 037_scoring_events
+Revises: 036_support_tickets
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "037_scoring_events"
+down_revision = "036_support_tickets"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "scoring_events",
+        sa.Column("id", sa.UUID(as_uuid=True), primary_key=True),
+        sa.Column("tenant_id", sa.UUID(as_uuid=True), nullable=False, index=True),
+        sa.Column("listing_id", sa.UUID(as_uuid=True), nullable=False, index=True),
+        sa.Column("asset_id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("room_label", sa.String(100)),
+        sa.Column("features", postgresql.JSONB, nullable=False),
+        sa.Column("composite_score", sa.Float, nullable=False),
+        sa.Column("position", sa.Integer),
+        sa.Column("outcome", sa.String(20)),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("outcome_at", sa.DateTime(timezone=True)),
+    )
+    # Index for training data export: find all labeled rows
+    op.create_index(
+        "ix_scoring_events_outcome_not_null",
+        "scoring_events",
+        ["tenant_id", "created_at"],
+        postgresql_where=sa.text("outcome IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_scoring_events_outcome_not_null", table_name="scoring_events")
+    op.drop_table("scoring_events")

--- a/src/listingjet/agents/learning.py
+++ b/src/listingjet/agents/learning.py
@@ -1,8 +1,11 @@
-from sqlalchemy import select
+from datetime import datetime, timezone
+
+from sqlalchemy import select, update
 
 from listingjet.database import AsyncSessionLocal
 from listingjet.models.event import Event
 from listingjet.models.learning_weight import LearningWeight
+from listingjet.models.scoring_event import ScoringEvent
 from listingjet.services.weight_manager import WeightManager
 
 from .base import AgentContext, BaseAgent
@@ -60,6 +63,20 @@ class LearningAgent(BaseAgent):
                             weight=new_weight,
                             labeled_listing_count=1,
                         ))
+
+                    # Backfill outcome on ScoringEvent rows for XGBoost training data
+                    asset_id = event.payload.get("asset_id")
+                    now = datetime.now(timezone.utc)
+                    if asset_id:
+                        await session.execute(
+                            update(ScoringEvent)
+                            .where(
+                                ScoringEvent.listing_id == listing_id,
+                                ScoringEvent.asset_id == asset_id,
+                                ScoringEvent.outcome.is_(None),
+                            )
+                            .values(outcome=action, outcome_at=now)
+                        )
 
                     weights_updated += 1
 

--- a/src/listingjet/agents/packaging.py
+++ b/src/listingjet/agents/packaging.py
@@ -9,6 +9,7 @@ from listingjet.models.asset import Asset
 from listingjet.models.learning_weight import LearningWeight
 from listingjet.models.listing import Listing, ListingState
 from listingjet.models.package_selection import PackageSelection
+from listingjet.models.scoring_event import ScoringEvent
 from listingjet.models.tenant import Tenant
 from listingjet.models.vision_result import VisionResult
 from listingjet.services.weight_manager import WeightManager
@@ -83,7 +84,7 @@ class PackagingAgent(BaseAgent):
                     delete(PackageSelection).where(PackageSelection.listing_id == listing_id)
                 )
 
-                # Write PackageSelection rows
+                # Write PackageSelection + ScoringEvent rows
                 for position, (score, asset_id, vr) in enumerate(top):
                     ps = PackageSelection(
                         tenant_id=tenant_id,
@@ -95,6 +96,25 @@ class PackagingAgent(BaseAgent):
                         composite_score=score,
                     )
                     session.add(ps)
+
+                    # Log features for XGBoost training data
+                    lw = weight_map.get(vr.room_label) if vr.room_label else None
+                    session.add(ScoringEvent(
+                        tenant_id=tenant_id,
+                        listing_id=listing_id,
+                        asset_id=asset_id,
+                        room_label=vr.room_label,
+                        features={
+                            "quality_score": vr.quality_score,
+                            "commercial_score": vr.commercial_score,
+                            "hero_candidate": vr.hero_candidate or False,
+                            "room_weight": lw.weight if lw else 1.0,
+                            "tier": vr.tier,
+                            "labeled_listing_count": lw.labeled_listing_count if lw else 0,
+                        },
+                        composite_score=score,
+                        position=position,
+                    ))
 
                 # Compute average trust score
                 avg_score = sum(s[0] for s in top) / len(top) if top else 0.0

--- a/src/listingjet/api/listings_workflow.py
+++ b/src/listingjet/api/listings_workflow.py
@@ -3,7 +3,7 @@ import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from listingjet.api.deps import get_current_user
@@ -17,6 +17,7 @@ from listingjet.api.schemas.listings import (
 from listingjet.database import get_db
 from listingjet.models.asset import Asset
 from listingjet.models.listing import Listing, ListingState
+from listingjet.models.scoring_event import ScoringEvent
 from listingjet.models.tenant import Tenant
 from listingjet.models.user import User
 from listingjet.services.endpoint_rate_limit import rate_limit
@@ -91,6 +92,17 @@ async def approve_listing(
         record_review_turnaround(turnaround)
 
     listing.state = ListingState.APPROVED
+
+    # Backfill "approval" outcome on all un-labeled ScoringEvent rows for this listing
+    await db.execute(
+        update(ScoringEvent)
+        .where(
+            ScoringEvent.listing_id == listing_id,
+            ScoringEvent.outcome.is_(None),
+        )
+        .values(outcome="approval", outcome_at=datetime.now(timezone.utc))
+    )
+
     await db.commit()
     await db.refresh(listing)
 
@@ -152,6 +164,16 @@ async def reject_listing(
         raise HTTPException(status_code=400, detail=f"Invalid reason. Must be one of: {valid_reasons}")
 
     listing.state = ListingState.FAILED
+
+    # Backfill "rejection" outcome on all un-labeled ScoringEvent rows for this listing
+    await db.execute(
+        update(ScoringEvent)
+        .where(
+            ScoringEvent.listing_id == listing_id,
+            ScoringEvent.outcome.is_(None),
+        )
+        .values(outcome="rejection", outcome_at=datetime.now(timezone.utc))
+    )
 
     # Emit event BEFORE commit — outbox atomicity
     from listingjet.services.events import emit_event

--- a/src/listingjet/models/__init__.py
+++ b/src/listingjet/models/__init__.py
@@ -21,3 +21,4 @@ from .addon_catalog import AddonCatalog                      # noqa
 from .addon_purchase import AddonPurchase                    # noqa
 from .listing_permission import ListingPermission            # noqa
 from .listing_permission import ListingAuditLog              # noqa
+from .scoring_event import ScoringEvent                      # noqa

--- a/src/listingjet/models/scoring_event.py
+++ b/src/listingjet/models/scoring_event.py
@@ -1,0 +1,29 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import UUID, DateTime, Float, String, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from listingjet.database import Base
+
+
+class ScoringEvent(Base):
+    """Logs (features, score, outcome) for each photo scored by PackagingAgent.
+
+    Outcome is backfilled when the user approves, rejects, or swaps.
+    This table is the training dataset for the Phase 2 XGBoost model.
+    """
+
+    __tablename__ = "scoring_events"
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    listing_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    asset_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    room_label: Mapped[str | None] = mapped_column(String(100))
+    features: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    composite_score: Mapped[float] = mapped_column(Float, nullable=False)
+    position: Mapped[int | None]  # final rank in package (0=hero)
+    outcome: Mapped[str | None] = mapped_column(String(20))  # approval, rejection, swap_to, swap_from
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    outcome_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))


### PR DESCRIPTION
Log (features, composite_score, outcome) for every photo scored by
PackagingAgent. Outcomes are backfilled when users approve, reject,
or swap photos — giving a labeled training dataset for the Phase 2
XGBoost model upgrade.

https://claude.ai/code/session_01GSr2xh7stNMXWKYgni5BgG