### PR TITLE
fix: use presigned S3 URLs for Kling video generation

### DIFF
--- a/src/listingjet/agents/video.py
+++ b/src/listingjet/agents/video.py
@@ -265,12 +265,15 @@ class VideoAgent(BaseAgent):
             prompt = get_prompt_for_room(room, metadata)
             camera = get_camera_control(room)
 
+            # Convert S3 key to presigned URL for Kling API
+            image_url = self._storage.presigned_url(asset.file_path)
+
             async with self._semaphore:
                 if index > 0:
                     await asyncio.sleep(3)  # Stagger to avoid rate limits
                 try:
                     task_id = await self._kling.generate_clip(
-                        image_url=asset.file_path,
+                        image_url=image_url,
                         prompt=prompt,
                         negative_prompt=NEGATIVE_PROMPT,
                         camera_control=camera,


### PR DESCRIPTION
## Summary
- Kling API requires a publicly accessible URL, not an S3 key
- `asset.file_path` is an S3 key (`listings/.../photo.jpg`), causing `File is not in a valid base64 format` errors on all 12 clips
- Generate presigned URL via `StorageService.presigned_url()` before passing to Kling

## Test plan
- [x] 13 tests pass, lint clean
- [ ] Retry pipeline on listing `26327014` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)