### PR TITLE
fix: deploy workflow trigger master → main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to AWS
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary
- Deploy workflow triggers on `master` but default branch is `main`
- ECR images haven't been pushed since branch rename — all recent merges (PRs #146, #147, #150) are not deployed
- Changes `branches: [master]` to `branches: [main]` in deploy.yml

**Critical: unblocks all deployments.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)