### PR TITLE
fix: enable USE_MOCK_PROVIDERS in deploy CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to AWS
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
     env:
       DATABASE_URL: "postgresql+asyncpg://listingjet:password@localhost:5433/listingjet_test"
       DATABASE_URL_SYNC: "postgresql://listingjet:password@localhost:5433/listingjet_test"
-      JWT_SECRET: "test-secret"
+      JWT_SECRET: "test-secret-that-is-at-least-32-characters-long"
       REDIS_URL: "redis://localhost:6379/0"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,7 @@ jobs:
       DATABASE_URL_SYNC: "postgresql://listingjet:password@localhost:5433/listingjet_test"
       JWT_SECRET: "test-secret-that-is-at-least-32-characters-long"
       REDIS_URL: "redis://localhost:6379/0"
+      USE_MOCK_PROVIDERS: "true"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
CI test needs mock providers since no real API keys are available.