### PR TITLE
fix: upload-urls endpoint rejects >50 files

### DIFF
--- a/src/listingjet/api/listings_media.py
+++ b/src/listingjet/api/listings_media.py
@@ -66,8 +66,8 @@ async def get_upload_urls(
             files.append({"filename": f, "content_type": body.content_type})
         else:
             files.append({"filename": f.filename, "content_type": f.content_type or body.content_type})
-    if not files or len(files) > 50:
-        raise HTTPException(status_code=400, detail="Provide 1-50 files")
+    if not files or len(files) > 100:
+        raise HTTPException(status_code=400, detail="Provide 1-100 files")
 
     ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png"}
     storage = get_storage()

--- a/tests/test_api/test_uploads.py
+++ b/tests/test_api/test_uploads.py
@@ -38,31 +38,31 @@ async def _create_listing(client: AsyncClient, token: str) -> str:
 
 @pytest.mark.asyncio
 @patch("listingjet.api.listings_media.get_storage")
-async def test_upload_urls_max_50_files_succeeds(MockStorage, async_client: AsyncClient):
-    """Request presigned URLs for exactly 50 files → 200 with 50 URLs."""
+async def test_upload_urls_max_100_files_succeeds(MockStorage, async_client: AsyncClient):
+    """Request presigned URLs for exactly 100 files → 200 with 100 URLs."""
     mock_svc = MockStorage.return_value
     mock_svc.presigned_upload_url.return_value = "https://s3.example.com/presigned"
 
     token, _ = await _register(async_client)
     listing_id = await _create_listing(async_client, token)
 
-    filenames = [f"photo_{i}.jpg" for i in range(50)]
+    filenames = [f"photo_{i}.jpg" for i in range(100)]
     resp = await async_client.post(
         f"/listings/{listing_id}/upload-urls",
         json={"filenames": filenames},
         headers=_auth(token),
     )
     assert resp.status_code == 200
-    assert len(resp.json()["upload_urls"]) == 50
+    assert len(resp.json()["upload_urls"]) == 100
 
 
 @pytest.mark.asyncio
-async def test_upload_urls_51_files_returns_400(async_client: AsyncClient):
-    """Request presigned URLs for 51 files → 400."""
+async def test_upload_urls_101_files_returns_400(async_client: AsyncClient):
+    """Request presigned URLs for 101 files → 400."""
     token, _ = await _register(async_client)
     listing_id = await _create_listing(async_client, token)
 
-    filenames = [f"photo_{i}.jpg" for i in range(51)]
+    filenames = [f"photo_{i}.jpg" for i in range(101)]
     resp = await async_client.post(
         f"/listings/{listing_id}/upload-urls",
         json={"filenames": filenames},


### PR DESCRIPTION
Backend had hardcoded 50-file check separate from plan limits. Now 100.