### PR TITLE
Fix wizard stuck after photo upload

### DIFF
--- a/frontend/src/components/listings/creation-wizard/step-upload-photos.tsx
+++ b/frontend/src/components/listings/creation-wizard/step-upload-photos.tsx
@@ -210,14 +210,14 @@ export function StepUploadPhotos({ formData, onUpdate, onNext, onBack }: Props) 
       const registered = await apiClient.registerAssets(listingId, { assets });
 
       // Store uploaded assets in wizard state
-      const uploadedAssets = (registered as any).assets ?? [];
+      const returnedAssets = (registered as any).assets ?? [];
       onUpdate({
         uploadedAssets: [
           ...formData.uploadedAssets,
-          ...uploadedAssets.map((a: any) => ({
+          ...returnedAssets.map((a: any, i: number) => ({
             id: a.id,
-            filename: a.filename ?? a.file_path ?? "",
-            url: a.url ?? a.cdn_url ?? "",
+            filename: successful[i]?.file?.name ?? a.file_path ?? "",
+            url: "",
           })),
         ],
       });

--- a/src/listingjet/api/listings_media.py
+++ b/src/listingjet/api/listings_media.py
@@ -130,6 +130,7 @@ async def register_assets(
             detail=f"Asset limit reached ({existing_count}/{max_allowed}). Upgrade your plan for more.",
         )
 
+    created_assets = []
     for a in body.assets:
         asset = Asset(
             tenant_id=current_user.tenant_id,
@@ -139,11 +140,13 @@ async def register_assets(
             state="uploaded",
         )
         db.add(asset)
+        created_assets.append(asset)
 
     if listing.state == ListingState.NEW:
         listing.state = ListingState.UPLOADING
         # DRAFT listings stay in DRAFT — pipeline starts via /start-pipeline endpoint
 
+    await db.flush()  # assign IDs to created_assets
     await db.commit()
 
     # Trigger the pipeline if listing just entered UPLOADING
@@ -163,6 +166,7 @@ async def register_assets(
     return CreateAssetsResponse(
         count=len(body.assets),
         listing_state=listing.state.value,
+        assets=created_assets,
     )
 
 

--- a/src/listingjet/api/schemas/assets.py
+++ b/src/listingjet/api/schemas/assets.py
@@ -13,9 +13,17 @@ class CreateAssetsRequest(BaseModel):
     assets: list[AssetInput]
 
 
+class AssetSummary(BaseModel):
+    id: uuid.UUID
+    file_path: str
+
+    model_config = {"from_attributes": True}
+
+
 class CreateAssetsResponse(BaseModel):
     count: int
     listing_state: str
+    assets: list[AssetSummary]
 
 
 class AssetResponse(BaseModel):


### PR DESCRIPTION
## Summary
- `register_assets` API now returns created asset objects (`id`, `file_path`) in the response
- Frontend uses returned assets to populate wizard state, enabling the "Next: Virtual Staging" button
- Previously `uploadedAssets` was always empty because the API response had no `assets` field

## Test plan
- [x] 35 media/asset/upload tests pass
- [x] 13 plan limits tests pass
- [ ] Upload photos in wizard → verify Next button enables
- [ ] Proceed through virtual staging step

🤖 Generated with [Claude Code](https://claude.com/claude-code)