### PR TITLE
fix: Use thumbnail_url for imported photo thumbnails in creation wizard

### DIFF
--- a/frontend/src/components/listings/creation-wizard/step-upload-photos.tsx
+++ b/frontend/src/components/listings/creation-wizard/step-upload-photos.tsx
@@ -262,10 +262,10 @@ export function StepUploadPhotos({ formData, onUpdate, onNext, onBack }: Props) 
               // Refresh uploaded assets list
               try {
                 const assets = await apiClient.getAssets(listingId);
-                const mapped = (assets as any[]).map((a: any) => ({
+                const mapped = assets.map((a) => ({
                   id: a.id,
                   filename: a.file_path?.split("/").pop() ?? "",
-                  url: a.url ?? "",
+                  url: a.thumbnail_url ?? "",
                 }));
                 onUpdate({ uploadedAssets: mapped });
               } catch {


### PR DESCRIPTION
The asset list endpoint returns presigned URLs in `thumbnail_url`, not `url`. The wizard was mapping `a.url` (undefined) which produced blank thumbnails after a link import.

One-line fix: `a.url` → `a.thumbnail_url`

https://claude.ai/code/session_01GJLk6wwJhEed67fy8bkM7d