### PR TITLE
feat: health weights persistence, AI consent, E2E tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,7 @@ jobs:
       - run: python -m pytest --tb=short -q
 
   deploy:
+    needs: test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Docker Build
 
 on:
   push:
-    branches: [main, master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
 
 jobs:

--- a/MASTER_TODO.md
+++ b/MASTER_TODO.md
@@ -43,7 +43,7 @@ Compiled from: `TODO.md`, `PRE_LAUNCH_AUDIT.md`, `ADMIN_DASHBOARD_PROGRESS.md`, 
 ### Data Integrity
 - [x] **HIGH-5: Outbox poller can duplicate webhook deliveries** — `X-ListingJet-Idempotency-Key` header added
 - [x] **HIGH-6: Unbounded analytics queries** — pagination with offset/limit on `/analytics/credits`
-- [ ] **Dual credit systems (Audit #8)** — `CreditAccount` table vs `Tenant.credit_balance` are two sources of truth; needs product decision
+- [x] **Dual credit systems (Audit #8)** — Dropped `Tenant.credit_balance`; `CreditAccount` is sole source of truth (migration 046)
 
 ### Deployment
 - [ ] **Deploy backend with new analytics endpoints** (ECR push + ECS redeploy)
@@ -148,6 +148,16 @@ Compiled from: `TODO.md`, `PRE_LAUNCH_AUDIT.md`, `ADMIN_DASHBOARD_PROGRESS.md`, 
 - [x] Cancel listing reuses `FAILED` state (Audit #16) — `CANCELLED` enum added in migration 024
 - [x] Brand Kit migration gap (Audit #22) — chain is correct (011→013), gap is harmless
 - [x] **10 service modules have zero test coverage** (HIGH-8) — added tests for account_lifecycle, audit, notifications, email_templates, link_import, endcard, drip_scheduler (3 remaining: canva_tokens, idx_feed_poller — require external mocks)
+
+### Session Apr 9, 2026 — Resolved
+- [x] **Dependabot cryptography CVE-2026-39892** — merged #195, bumped to 46.0.7
+- [x] **Dual credit systems** — dropped `Tenant.credit_balance`, migration 046
+- [x] **CI workflows reference `master`** — removed dead branch from lint/docker/test workflows
+- [x] **Deploy not gated on tests** — added `needs: test` to deploy job
+- [x] **IDX API keys stored plaintext** — added Fernet encryption via `FIELD_ENCRYPTION_KEY` env var
+- [x] **Health score history no cleanup** — added 90-day cleanup to `data_retention.py`
+- [x] **Video prompts generic** — expanded to 31 room types, spatial walkthrough ordering
+- [x] **No automatic market tracking** — added `MarketTracker` using ATTOM API (zero agent setup)
 
 ### Deferred to Post-Launch
 - [ ] Password reset flow

--- a/alembic/versions/046_drop_tenant_credit_balance.py
+++ b/alembic/versions/046_drop_tenant_credit_balance.py
@@ -1,0 +1,25 @@
+"""Drop legacy credit_balance column from tenants table.
+
+CreditAccount is the single source of truth for credit balances.
+Tenant.credit_balance was a legacy duplicate that could drift out of sync.
+
+Revision ID: 046_drop_credit_balance
+Revises: 045_phase5_enrichments
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "046_drop_credit_balance"
+down_revision = "045_phase5_enrichments"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("tenants", "credit_balance")
+
+
+def downgrade() -> None:
+    op.add_column("tenants", sa.Column("credit_balance", sa.Integer(), server_default="0", nullable=False))

--- a/alembic/versions/047_tenant_health_weights.py
+++ b/alembic/versions/047_tenant_health_weights.py
@@ -1,0 +1,34 @@
+"""Persist custom health score weights per tenant.
+
+Revision ID: 047_tenant_health_weights
+Revises: 046_drop_credit_balance
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "047_tenant_health_weights"
+down_revision = "046_drop_credit_balance"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tenant_health_weights",
+        sa.Column("id", sa.UUID(), primary_key=True),
+        sa.Column("tenant_id", sa.UUID(), nullable=False),
+        sa.Column("media", sa.Float(), nullable=False, server_default="0.30"),
+        sa.Column("content", sa.Float(), nullable=False, server_default="0.20"),
+        sa.Column("velocity", sa.Float(), nullable=False, server_default="0.15"),
+        sa.Column("syndication", sa.Float(), nullable=False, server_default="0.20"),
+        sa.Column("market", sa.Float(), nullable=False, server_default="0.15"),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("ix_thw_tenant_id", "tenant_health_weights", ["tenant_id"])
+    op.create_unique_constraint("uq_thw_tenant", "tenant_health_weights", ["tenant_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("tenant_health_weights")

--- a/alembic/versions/048_ai_consent_fields.py
+++ b/alembic/versions/048_ai_consent_fields.py
@@ -1,0 +1,27 @@
+"""Add AI processing consent fields to users.
+
+Revision ID: 048_ai_consent
+Revises: 047_tenant_health_weights
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "048_ai_consent"
+down_revision = "047_tenant_health_weights"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("ai_consent_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("users", sa.Column("ai_consent_version", sa.String(20), nullable=True))
+
+    # Backfill: existing users who accepted ToS also accepted AI processing
+    op.execute("UPDATE users SET ai_consent_at = consent_at, ai_consent_version = '1.0' WHERE consent_at IS NOT NULL")
+
+
+def downgrade() -> None:
+    op.drop_column("users", "ai_consent_version")
+    op.drop_column("users", "ai_consent_at")

--- a/src/listingjet/agents/health_score.py
+++ b/src/listingjet/agents/health_score.py
@@ -6,6 +6,8 @@ Emits health.score.updated event and health.score.alert if below threshold.
 """
 import logging
 
+from sqlalchemy import select
+
 from listingjet.database import AsyncSessionLocal
 from listingjet.models.tenant import Tenant
 from listingjet.services import health_score as hs
@@ -25,15 +27,30 @@ class HealthScoreAgent(BaseAgent):
 
     async def execute(self, context: AgentContext) -> dict:
         async with self.session_scope(context) as (session, listing_id, tenant_id):
+            from listingjet.models.tenant_health_weights import TenantHealthWeights
+
             # Resolve tenant plan + custom weights
             tenant = await session.get(Tenant, tenant_id)
             plan = tenant.plan if tenant else "starter"
+
+            custom_weights = None
+            if plan in ("team", "enterprise"):
+                thw = (await session.execute(
+                    select(TenantHealthWeights).where(TenantHealthWeights.tenant_id == tenant_id)
+                )).scalar_one_or_none()
+                if thw:
+                    custom_weights = {
+                        "media": thw.media, "content": thw.content,
+                        "velocity": thw.velocity, "syndication": thw.syndication,
+                        "market": thw.market,
+                    }
 
             score = await hs.calculate(
                 session=session,
                 listing_id=listing_id,
                 tenant_id=tenant_id,
                 plan=plan,
+                custom_weights=custom_weights,
             )
 
             await self.emit(session, context, "health.score.updated", {

--- a/src/listingjet/agents/video.py
+++ b/src/listingjet/agents/video.py
@@ -14,6 +14,7 @@ from listingjet.agents.video_template import (
     NEGATIVE_PROMPT,
     STANDARD_60S,
     VIDEO_EXCLUDED_LABELS,
+    WALKTHROUGH_ORDER,
     VideoTemplate,
     get_prompt_for_room,
 )
@@ -231,12 +232,12 @@ class VideoAgent(BaseAgent):
                         room = "unknown"
                 seen[aid] = (ps, asset, vr, score, room)
 
-        # Bucket photos by room category, each sorted by score desc
+        # Bucket photos by room category
         drones: list[tuple] = []
         exteriors: list[tuple] = []
         interiors: list[tuple] = []
         for aid, (ps, asset, vr, score, room) in seen.items():
-            entry = (ps, asset, vr, score)
+            entry = (ps, asset, vr, score, room)
             if room in DRONE_ROOMS:
                 drones.append(entry)
             elif room in EXTERIOR_ROOMS:
@@ -246,7 +247,12 @@ class VideoAgent(BaseAgent):
 
         drones.sort(key=lambda e: e[3], reverse=True)
         exteriors.sort(key=lambda e: e[3], reverse=True)
-        interiors.sort(key=lambda e: e[3], reverse=True)
+
+        # Sort interiors by walkthrough order (spatial flow), score as tiebreaker.
+        # Rooms not in WALKTHROUGH_ORDER go to the end, sorted by score.
+        walk_index = {room: i for i, room in enumerate(WALKTHROUGH_ORDER)}
+        max_walk = len(WALKTHROUGH_ORDER)
+        interiors.sort(key=lambda e: (walk_index.get(e[4], max_walk), -e[3]))
 
         # All photos pooled and score-sorted — used as the padding reservoir
         all_photos = sorted(
@@ -287,23 +293,23 @@ class VideoAgent(BaseAgent):
         else:
             positions[1] = positions[0]
 
-        # Positions 3..N-1 (interior slots, score-descending)
+        # Positions 3..N-1 (interior slots in walkthrough order)
         interior_slots = total - 3  # positions[2] .. positions[total-2]
-        interior_pool = list(interiors)  # already score-sorted desc
+        interior_pool = list(interiors)  # already walkthrough-sorted
         for i in range(interior_slots):
             slot_idx = 2 + i
             if interior_pool:
                 positions[slot_idx] = interior_pool.pop(0)
             else:
-                # Pad with highest-scored interior if we have any; else best photo
+                # Pad with first interior if we have any; else best photo
                 if interiors:
                     positions[slot_idx] = interiors[0]
                 else:
                     # No interiors at all — pad from all_photos, avoiding adjacent duplicates
                     positions[slot_idx] = self._pad_pick(all_photos, positions, slot_idx)
 
-        # Strip the (ps, asset, vr, score) score element for downstream compatibility
-        return [(ps, asset, vr) for (ps, asset, vr, _score) in positions]
+        # Strip score/room extras for downstream compatibility → (ps, asset, vr)
+        return [(e[0], e[1], e[2]) for e in positions]
 
     def _pad_pick(self, pool: list, positions: list, slot_idx: int) -> tuple:
         """Pick a padding photo from pool, avoiding exact duplicate of neighbor if possible."""

--- a/src/listingjet/agents/video_template.py
+++ b/src/listingjet/agents/video_template.py
@@ -4,92 +4,165 @@ from dataclasses import dataclass
 
 ROOM_PROMPTS: dict[str, str] = {
     "drone": (
-        "Aerial drone footage slowly gliding forward over residential property, "
-        "camera tilts gently downward revealing rooftop and landscaping, "
-        "trees sway softly in the breeze, shadows shift across the lawn, "
+        "Aerial drone footage gliding forward over residential property, "
+        "camera tilts gently downward revealing rooftop and full lot, "
+        "trees sway softly, shadows move across manicured lawn, "
         "golden hour sunlight, smooth continuous forward motion, cinematic 4K real estate"
     ),
     "exterior": (
-        "Camera steadily pushes forward along walkway toward front door of house, "
-        "parallax movement past landscaping and columns, porch light glows warmly, "
-        "leaves rustle gently, late afternoon sun casts long shadows across facade, "
+        "Camera pushes steadily forward along front walkway toward entrance, "
+        "parallax past landscaping, columns, and architectural details, "
+        "late afternoon sun casts warm directional light across facade, "
         "smooth dolly motion, professional real estate cinematography"
     ),
     "exterior_rear": (
-        "Camera glides laterally across backyard revealing patio and outdoor living space, "
-        "plants sway gently in breeze, sunlight dapples through tree canopy, "
+        "Camera glides laterally across rear of home revealing patio and outdoor living, "
+        "plants sway gently, sunlight dapples through tree canopy onto siding, "
         "smooth tracking shot with natural depth parallax, cinematic real estate"
     ),
+    "entryway": (
+        "Camera pushes forward through front entry into home, light pours in from doorway, "
+        "shadows shift across floor as camera advances, "
+        "architectural details emerge with depth parallax, "
+        "smooth continuous dolly, welcoming first impression, professional cinematography"
+    ),
+    "foyer": (
+        "Camera enters foyer and slowly pans upward revealing ceiling height, "
+        "natural light from adjacent windows creates warm tones, "
+        "smooth tilt motion with foreground depth, elegant first impression, cinematic interior"
+    ),
     "living_room": (
-        "Camera pushes slowly forward through spacious living room, "
-        "natural light streams through windows casting moving shadows on floor, "
-        "curtains drift gently, parallax reveals furniture depth and room scale, "
+        "Camera pushes slowly forward through living room, "
+        "natural light streams through windows illuminating textures and surfaces, "
+        "parallax reveals furniture arrangement and room scale, "
         "warm ambient atmosphere, smooth continuous dolly, professional interior cinematography"
+    ),
+    "family_room": (
+        "Camera tracks laterally through family room revealing comfortable layout, "
+        "soft window light creates warm atmosphere, "
+        "depth parallax between seating and built-in features, "
+        "smooth tracking motion, inviting casual living space, cinematic interior"
     ),
     "kitchen": (
         "Camera glides forward into kitchen revealing countertops and cabinetry, "
-        "overhead pendant lights cast warm pools of light on surfaces, "
-        "subtle reflections shift on stainless steel and stone countertops, "
+        "pendant lights cast warm pools of light on work surfaces, "
+        "reflections shift subtly on appliances and stone countertops, "
         "smooth dolly push with natural parallax, bright modern interior, cinematic real estate"
     ),
-    "bedroom": (
-        "Camera slowly tracks right to left across bedroom, "
-        "soft natural light from windows illuminates bedding and furniture, "
-        "gentle depth parallax between foreground and background elements, "
-        "peaceful serene atmosphere, smooth lateral tracking shot, professional interior"
-    ),
-    "primary_bedroom": (
-        "Camera pushes gently forward into luxurious primary suite, "
-        "morning light cascades through large windows, soft shadows move across bed, "
-        "parallax reveals room depth and architectural details, "
-        "smooth continuous dolly motion, elegant luxury interior cinematography"
-    ),
-    "bathroom": (
-        "Camera glides forward into bathroom revealing tile work and fixtures, "
-        "light reflects and shimmers off glass shower door and mirror surfaces, "
-        "clean bright illumination with subtle caustic reflections on tile, "
-        "smooth push-in motion, spa-like atmosphere, professional real estate"
-    ),
-    "primary_bathroom": (
-        "Camera tracks laterally across primary bathroom revealing double vanity and soaking tub, "
-        "light plays across marble surfaces and chrome fixtures, water-like reflections shimmer, "
-        "smooth tracking shot with depth parallax, luxury spa interior cinematography"
-    ),
     "dining_room": (
-        "Camera pushes forward through dining area, chandelier light creates warm ambiance, "
-        "subtle light shifts across table surface and wall art, "
-        "parallax between chairs and background reveals room depth, "
+        "Camera pushes forward into dining area, fixture light creates warm ambiance, "
+        "light shifts across table surface and wall details, "
+        "parallax between furnishings and background reveals room proportion, "
         "smooth dolly motion, elegant interior, professional real estate cinematography"
     ),
+    "breakfast_nook": (
+        "Camera glides toward breakfast area adjacent to kitchen, "
+        "morning light streams through nearby windows across table, "
+        "smooth push-in with subtle parallax, bright casual dining space, cinematic interior"
+    ),
+    "primary_bedroom": (
+        "Camera pushes gently forward into primary suite, "
+        "soft light cascades through large windows across bed and furnishings, "
+        "parallax reveals room depth and architectural details, "
+        "smooth continuous dolly motion, elegant retreat, luxury interior cinematography"
+    ),
+    "bedroom": (
+        "Camera slowly tracks laterally across bedroom, "
+        "soft natural light from windows illuminates surfaces, "
+        "gentle depth parallax between foreground and background, "
+        "peaceful atmosphere, smooth lateral tracking shot, professional interior"
+    ),
+    "primary_bathroom": (
+        "Camera tracks laterally revealing double vanity and spa features, "
+        "light plays across tile, stone, and chrome surfaces, "
+        "subtle reflections shimmer on glass and mirror, "
+        "smooth tracking shot with depth parallax, luxury spa atmosphere, cinematic interior"
+    ),
+    "bathroom": (
+        "Camera glides forward into bathroom revealing tile and fixtures, "
+        "light reflects off glass and mirror surfaces, "
+        "clean bright illumination with subtle caustic reflections, "
+        "smooth push-in motion, spa-like atmosphere, professional real estate"
+    ),
     "office": (
-        "Camera slowly tracks across home office, natural window light shifts across desk surface, "
-        "bookshelves and decor create layered depth with parallax movement, "
-        "smooth lateral tracking shot, productive modern atmosphere, cinematic interior"
+        "Camera slowly tracks across home office, window light shifts across desk, "
+        "shelving and decor create layered depth with parallax, "
+        "smooth lateral tracking shot, focused productive atmosphere, cinematic interior"
+    ),
+    "laundry": (
+        "Camera pushes gently forward into laundry room revealing clean organized space, "
+        "bright even illumination across cabinetry and appliances, "
+        "smooth dolly motion, functional modern utility space, professional real estate"
+    ),
+    "mudroom": (
+        "Camera glides through mudroom entry revealing storage and organization, "
+        "natural light from adjacent door, clean practical space, "
+        "smooth forward motion, inviting transitional area, cinematic interior"
+    ),
+    "closet": (
+        "Camera pushes slowly into walk-in closet revealing organization system, "
+        "even recessed lighting illuminates shelving and hanging space, "
+        "smooth dolly forward, spacious organized storage, professional interior"
+    ),
+    "staircase": (
+        "Camera tilts upward following staircase line revealing second floor landing, "
+        "light shifts across railing and wall surfaces, "
+        "smooth vertical pan motion, architectural detail, professional real estate"
+    ),
+    "hallway": (
+        "Camera glides forward down hallway, wall art and doorways create depth parallax, "
+        "light from adjacent rooms spills across floor, "
+        "smooth forward dolly, connecting spaces, cinematic interior"
     ),
     "garage": (
         "Camera pushes forward into spacious garage, overhead lighting illuminates clean floor, "
-        "depth parallax reveals storage and organization, "
-        "smooth dolly motion, even bright lighting, professional real estate"
+        "depth parallax reveals storage capacity, "
+        "smooth dolly motion, bright even lighting, professional real estate"
     ),
     "pool": (
-        "Camera glides slowly forward over pool, water surface ripples and shimmers with light, "
-        "reflections dance across surrounding deck, palm fronds sway gently overhead, "
+        "Camera glides slowly forward over pool, water surface ripples and shimmers, "
+        "reflections dance across surrounding deck and coping, "
         "resort-style atmosphere, smooth aerial drift, cinematic outdoor luxury"
     ),
+    "patio": (
+        "Camera tracks laterally across covered patio revealing outdoor living setup, "
+        "dappled sunlight through overhead structure, furniture creates foreground depth, "
+        "smooth tracking shot, outdoor entertaining space, cinematic real estate"
+    ),
+    "deck": (
+        "Camera glides across deck revealing railing and views beyond, "
+        "natural light and shadows from overhead, "
+        "smooth lateral tracking with landscape depth, outdoor living, cinematic real estate"
+    ),
     "backyard": (
-        "Camera tracks laterally across backyard revealing landscaping and outdoor features, "
+        "Camera tracks laterally across backyard revealing full landscaping, "
         "leaves and grass sway gently in breeze, sunlight filters through trees, "
         "natural depth parallax, smooth tracking shot, inviting outdoor living, cinematic real estate"
     ),
-    "entryway": (
-        "Camera pushes forward through grand entryway, light pours in from above, "
-        "shadows shift across floor as camera advances, architectural details emerge with parallax, "
-        "smooth continuous dolly into home, welcoming atmosphere, professional cinematography"
-    ),
     "basement": (
         "Camera glides forward through finished basement, recessed lighting creates even illumination, "
-        "depth parallax reveals entertainment area and living space, "
+        "depth parallax reveals entertainment and living area, "
         "smooth dolly motion, modern finished interior, professional real estate"
+    ),
+    "theater": (
+        "Camera pushes slowly forward into home theater, ambient lighting along walls, "
+        "seating and screen create dramatic depth, "
+        "smooth cinematic dolly, entertainment luxury, professional interior"
+    ),
+    "gym": (
+        "Camera tracks laterally through home gym revealing equipment and mirrors, "
+        "bright even lighting, reflections add depth, "
+        "smooth tracking shot, active lifestyle space, professional real estate"
+    ),
+    "wine_cellar": (
+        "Camera pushes forward into wine cellar, warm accent lighting across racks, "
+        "subtle reflections on glass bottles, temperature-controlled atmosphere, "
+        "smooth dolly motion, luxury entertaining feature, cinematic interior"
+    ),
+    "bonus_room": (
+        "Camera glides forward into versatile bonus room, natural light from windows, "
+        "flexible open space with depth parallax, "
+        "smooth dolly motion, adaptable living area, professional real estate"
     ),
 }
 
@@ -97,19 +170,33 @@ ROOM_CAMERA_CONTROLS: dict[str, dict[str, int]] = {
     "drone": {"zoom": 2, "horizontal": 3},
     "exterior": {"zoom": 4, "horizontal": 0},
     "exterior_rear": {"zoom": 3, "horizontal": 2},
+    "entryway": {"zoom": 5, "horizontal": 0},
+    "foyer": {"zoom": 3, "horizontal": 0},
     "living_room": {"zoom": 4, "horizontal": -2},
+    "family_room": {"zoom": 3, "horizontal": -3},
     "kitchen": {"zoom": 5, "horizontal": 0},
-    "bedroom": {"zoom": 3, "horizontal": -3},
-    "primary_bedroom": {"zoom": 4, "horizontal": -2},
-    "bathroom": {"zoom": 3, "horizontal": 0},
-    "primary_bathroom": {"zoom": 3, "horizontal": 2},
     "dining_room": {"zoom": 4, "horizontal": -2},
+    "breakfast_nook": {"zoom": 4, "horizontal": 0},
+    "primary_bedroom": {"zoom": 4, "horizontal": -2},
+    "bedroom": {"zoom": 3, "horizontal": -3},
+    "primary_bathroom": {"zoom": 3, "horizontal": 2},
+    "bathroom": {"zoom": 3, "horizontal": 0},
     "office": {"zoom": 3, "horizontal": 3},
+    "laundry": {"zoom": 3, "horizontal": 0},
+    "mudroom": {"zoom": 3, "horizontal": 0},
+    "closet": {"zoom": 4, "horizontal": 0},
+    "staircase": {"zoom": 2, "horizontal": 0},
+    "hallway": {"zoom": 4, "horizontal": 0},
     "garage": {"zoom": 3, "horizontal": 0},
     "pool": {"zoom": 2, "horizontal": 3},
+    "patio": {"zoom": 3, "horizontal": -3},
+    "deck": {"zoom": 2, "horizontal": -3},
     "backyard": {"zoom": 2, "horizontal": -3},
-    "entryway": {"zoom": 5, "horizontal": 0},
     "basement": {"zoom": 4, "horizontal": 0},
+    "theater": {"zoom": 4, "horizontal": 0},
+    "gym": {"zoom": 3, "horizontal": 3},
+    "wine_cellar": {"zoom": 4, "horizontal": 0},
+    "bonus_room": {"zoom": 3, "horizontal": 0},
 }
 
 NEGATIVE_PROMPT = (
@@ -129,11 +216,30 @@ VIDEO_EXCLUDED_LABELS: frozenset[str] = frozenset({
 FEATURE_TAGS: dict[str, list[str]] = {
     "kitchen": ["island", "quartz_counters", "granite_counters", "stainless_appliances"],
     "bathroom": ["soaking_tub", "walk_in_shower", "double_vanity"],
+    "primary_bathroom": ["soaking_tub", "walk_in_shower", "double_vanity", "heated_floors"],
     "living_room": ["vaulted_ceilings", "fireplace", "hardwood_floors", "built_ins"],
+    "family_room": ["fireplace", "built_ins", "hardwood_floors"],
     "exterior": ["pool", "outdoor_kitchen", "fire_pit", "deck", "patio"],
     "bedroom": ["walk_in_closet", "tray_ceiling"],
+    "primary_bedroom": ["walk_in_closet", "tray_ceiling", "sitting_area"],
     "basement": ["theater", "gym", "wet_bar"],
 }
+
+# Walkthrough order for spatial flow (exterior → entry → main living → private → outdoor → aerial close)
+# Rooms not in this list are placed by score after the last matched room.
+WALKTHROUGH_ORDER: list[str] = [
+    "entryway", "foyer",
+    "living_room", "family_room",
+    "kitchen", "breakfast_nook", "dining_room",
+    "office",
+    "hallway", "staircase",
+    "primary_bedroom", "primary_bathroom", "closet",
+    "bedroom", "bathroom",
+    "laundry", "mudroom",
+    "basement", "theater", "gym", "wine_cellar", "bonus_room",
+    "patio", "deck", "pool", "backyard",
+    "garage",
+]
 
 # Room buckets for template-based photo selection
 DRONE_ROOMS: frozenset[str] = frozenset({"drone"})

--- a/src/listingjet/api/admin_tenants.py
+++ b/src/listingjet/api/admin_tenants.py
@@ -33,14 +33,34 @@ async def list_tenants(
     db: AsyncSession = Depends(get_db_admin),
 ):
     """List all tenants with pagination. Requires superadmin role."""
+    from listingjet.models.credit_account import CreditAccount
+
     total = (await db.execute(select(func.count(Tenant.id)))).scalar() or 0
     offset = (page - 1) * page_size
     result = await db.execute(
         select(Tenant).order_by(Tenant.created_at.desc()).offset(offset).limit(page_size)
     )
     tenants = result.scalars().all()
+
+    # Look up credit balances from CreditAccount (the single source of truth)
+    tenant_ids = [t.id for t in tenants]
+    if tenant_ids:
+        balances_result = await db.execute(
+            select(CreditAccount.tenant_id, CreditAccount.balance)
+            .where(CreditAccount.tenant_id.in_(tenant_ids))
+        )
+        balance_map = {row.tenant_id: row.balance for row in balances_result}
+    else:
+        balance_map = {}
+
+    items = []
+    for t in tenants:
+        resp = TenantResponse.model_validate(t)
+        resp.credit_balance = balance_map.get(t.id, 0)
+        items.append(resp)
+
     return {
-        "items": [TenantResponse.model_validate(t) for t in tenants],
+        "items": items,
         "total": total,
         "page": page,
         "page_size": page_size,
@@ -215,7 +235,6 @@ async def adjust_credits(
         )
 
     credit_acct.balance = new_balance
-    tenant.credit_balance = new_balance  # keep in sync for backward compat
 
     account_id = credit_acct.id
     txn = CreditTransaction(

--- a/src/listingjet/api/auth.py
+++ b/src/listingjet/api/auth.py
@@ -71,6 +71,8 @@ async def register(body: RegisterRequest, request: Request, _rl=Depends(rate_lim
         role=UserRole.ADMIN,
         consent_at=datetime.now(timezone.utc),
         consent_version="2026-04-03",
+        ai_consent_at=datetime.now(timezone.utc),
+        ai_consent_version="1.0",
     )
     db.add(user)
     await emit_event(
@@ -190,6 +192,29 @@ async def login(body: LoginRequest, request: Request, _rl=Depends(rate_limit(10,
 @router.get("/me", response_model=UserResponse)
 async def get_me(current_user: User = Depends(get_current_user)):
     return current_user
+
+
+class AiConsentRequest(BaseModel):
+    consent: bool
+
+
+@router.post("/ai-consent")
+async def update_ai_consent(
+    body: AiConsentRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Record or revoke AI processing consent for the current user."""
+    from datetime import datetime, timezone
+    user = await db.get(User, current_user.id)
+    if body.consent:
+        user.ai_consent_at = datetime.now(timezone.utc)
+        user.ai_consent_version = "1.0"
+    else:
+        user.ai_consent_at = None
+        user.ai_consent_version = None
+    await db.commit()
+    return {"ai_consent": body.consent, "ai_consent_at": str(user.ai_consent_at) if user.ai_consent_at else None}
 
 
 # ---------------------------------------------------------------------------

--- a/src/listingjet/api/auth.py
+++ b/src/listingjet/api/auth.py
@@ -71,8 +71,8 @@ async def register(body: RegisterRequest, request: Request, _rl=Depends(rate_lim
         role=UserRole.ADMIN,
         consent_at=datetime.now(timezone.utc),
         consent_version="2026-04-03",
-        ai_consent_at=datetime.now(timezone.utc),
-        ai_consent_version="1.0",
+        ai_consent_at=datetime.now(timezone.utc) if body.ai_consent else None,
+        ai_consent_version="1.0" if body.ai_consent else None,
     )
     db.add(user)
     await emit_event(

--- a/src/listingjet/api/billing.py
+++ b/src/listingjet/api/billing.py
@@ -395,7 +395,7 @@ async def _handle_subscription_deleted(
     if not tenant:
         return
 
-    # Downgrade to free — preserve credit_balance (purchased credits are theirs)
+    # Downgrade to free — CreditAccount balance is preserved (purchased credits are theirs)
     apply_plan_credits(tenant, "free")
     tenant.stripe_subscription_id = None
     await db.commit()

--- a/src/listingjet/api/listing_health.py
+++ b/src/listingjet/api/listing_health.py
@@ -39,6 +39,7 @@ from listingjet.models.listing import Listing
 from listingjet.models.listing_health_score import ListingHealthScore
 from listingjet.models.tenant import Tenant
 from listingjet.models.user import User
+from listingjet.services import field_encryption
 from listingjet.services import health_score as hs
 
 router = APIRouter()
@@ -233,7 +234,7 @@ async def create_idx_feed(
         tenant_id=current_user.tenant_id,
         name=body.name,
         base_url=body.base_url,
-        api_key_encrypted=body.api_key,  # TODO: encrypt with Fernet in production
+        api_key_encrypted=field_encryption.encrypt(body.api_key),
         board_id=body.board_id,
         poll_interval_minutes=body.poll_interval_minutes,
     )
@@ -269,7 +270,7 @@ async def update_idx_feed(
 
     for field, value in body.model_dump(exclude_unset=True).items():
         if field == "api_key" and value is not None:
-            config.api_key_encrypted = value  # TODO: encrypt
+            config.api_key_encrypted = field_encryption.encrypt(value)
         elif hasattr(config, field):
             setattr(config, field, value)
 

--- a/src/listingjet/api/listing_health.py
+++ b/src/listingjet/api/listing_health.py
@@ -302,8 +302,22 @@ async def get_health_weights(
     db: AsyncSession = Depends(get_db),
 ) -> HealthWeightsResponse:
     """Get current health score weights for the tenant."""
+    from listingjet.models.tenant_health_weights import TenantHealthWeights
+
     tenant = await db.get(Tenant, current_user.tenant_id)
     plan = tenant.plan if tenant else "starter"
+
+    # Check for custom weights first
+    custom = (await db.execute(
+        select(TenantHealthWeights).where(TenantHealthWeights.tenant_id == current_user.tenant_id)
+    )).scalar_one_or_none()
+
+    if custom and plan in ("team", "enterprise"):
+        return HealthWeightsResponse(
+            media=custom.media, content=custom.content, velocity=custom.velocity,
+            syndication=custom.syndication, market=custom.market,
+        )
+
     weights = hs._resolve_weights(plan)
     return HealthWeightsResponse(
         media=weights.get("media", 0),
@@ -321,6 +335,8 @@ async def update_health_weights(
     db: AsyncSession = Depends(get_db),
 ) -> HealthWeightsResponse:
     """Customize health score weights (Enterprise only)."""
+    from listingjet.models.tenant_health_weights import TenantHealthWeights
+
     tenant = await db.get(Tenant, current_user.tenant_id)
     if not tenant or tenant.plan not in ("team", "enterprise"):
         raise HTTPException(403, "Custom health weights require Enterprise plan")
@@ -329,8 +345,25 @@ async def update_health_weights(
     if not (0.99 <= total <= 1.01):
         raise HTTPException(422, f"Weights must sum to 1.0 (got {total:.2f})")
 
-    # TODO: persist custom weights in tenant metadata or dedicated table
-    # For now, return the requested weights
+    existing = (await db.execute(
+        select(TenantHealthWeights).where(TenantHealthWeights.tenant_id == current_user.tenant_id)
+    )).scalar_one_or_none()
+
+    if existing:
+        existing.media = body.media
+        existing.content = body.content
+        existing.velocity = body.velocity
+        existing.syndication = body.syndication
+        existing.market = body.market
+    else:
+        db.add(TenantHealthWeights(
+            tenant_id=current_user.tenant_id,
+            media=body.media, content=body.content, velocity=body.velocity,
+            syndication=body.syndication, market=body.market,
+        ))
+
+    await db.flush()
+
     return HealthWeightsResponse(
         media=body.media,
         content=body.content,

--- a/src/listingjet/api/listings_draft.py
+++ b/src/listingjet/api/listings_draft.py
@@ -87,6 +87,10 @@ async def start_pipeline(
     if listing.state != ListingState.DRAFT:
         raise HTTPException(status_code=409, detail=f"Can only start pipeline for DRAFT listings, current: {listing.state.value}")
 
+    # Verify AI processing consent
+    if not current_user.ai_consent_at:
+        raise HTTPException(status_code=403, detail="AI processing consent required. Update consent in account settings.")
+
     # Verify listing has assets
     asset_count = (await db.execute(
         select(Asset.id).where(Asset.listing_id == listing_id).limit(1)

--- a/src/listingjet/api/schemas/auth.py
+++ b/src/listingjet/api/schemas/auth.py
@@ -11,20 +11,13 @@ class RegisterRequest(BaseModel):
     company_name: str
     plan_tier: str | None = None
     consent: bool = False
-    ai_consent: bool = False
+    ai_consent: bool = True
 
     @field_validator("consent")
     @classmethod
     def consent_required(cls, v: bool) -> bool:
         if not v:
             raise ValueError("You must agree to the Privacy Policy to create an account")
-        return v
-
-    @field_validator("ai_consent")
-    @classmethod
-    def ai_consent_required(cls, v: bool) -> bool:
-        if not v:
-            raise ValueError("You must consent to AI processing of your listing photos")
         return v
 
     model_config = {

--- a/src/listingjet/api/schemas/auth.py
+++ b/src/listingjet/api/schemas/auth.py
@@ -11,12 +11,20 @@ class RegisterRequest(BaseModel):
     company_name: str
     plan_tier: str | None = None
     consent: bool = False
+    ai_consent: bool = False
 
     @field_validator("consent")
     @classmethod
     def consent_required(cls, v: bool) -> bool:
         if not v:
             raise ValueError("You must agree to the Privacy Policy to create an account")
+        return v
+
+    @field_validator("ai_consent")
+    @classmethod
+    def ai_consent_required(cls, v: bool) -> bool:
+        if not v:
+            raise ValueError("You must consent to AI processing of your listing photos")
         return v
 
     model_config = {

--- a/src/listingjet/config/__init__.py
+++ b/src/listingjet/config/__init__.py
@@ -119,6 +119,10 @@ class Settings(BaseSettings):
     reso_api_url: str = ""
     reso_api_key: str = ""
 
+    # Field-level encryption (Fernet key for IDX API keys, etc.)
+    # Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+    field_encryption_key: str = ""
+
     # Canva
     canva_api_key: str = ""
     canva_default_template_id: str = ""  # Canva Brand Template ID used when tenant has no override

--- a/src/listingjet/main.py
+++ b/src/listingjet/main.py
@@ -56,6 +56,7 @@ from listingjet.middleware.security_headers import SecurityHeadersMiddleware
 from listingjet.middleware.tenant import TenantMiddleware
 from listingjet.monitoring import init_monitoring
 from listingjet.services.idx_feed_poller import IdxFeedPoller
+from listingjet.services.market_tracker import MarketTracker
 from listingjet.services.outbox_poller import OutboxPoller
 
 setup_logging(app_env=settings.app_env, log_level=settings.log_level)
@@ -81,8 +82,10 @@ async def lifespan(app: FastAPI):
 
     outbox_task = None
     idx_task = None
+    market_task = None
     outbox_poller = None
     idx_poller = None
+    market_tracker = None
     try:
         outbox_poller = OutboxPoller(session_factory=AsyncSessionLocal)
         outbox_task = asyncio.create_task(outbox_poller.run())
@@ -95,9 +98,19 @@ async def lifespan(app: FastAPI):
     except Exception:
         logging.getLogger(__name__).warning("IDX feed poller failed to start — running without it")
 
+    try:
+        market_tracker = MarketTracker(session_factory=AsyncSessionLocal)
+        market_task = asyncio.create_task(market_tracker.run())
+    except Exception:
+        logging.getLogger(__name__).warning("Market tracker failed to start — running without it")
+
     yield
 
-    for poller_obj, task_obj in [(outbox_poller, outbox_task), (idx_poller, idx_task)]:
+    for poller_obj, task_obj in [
+        (outbox_poller, outbox_task),
+        (idx_poller, idx_task),
+        (market_tracker, market_task),
+    ]:
         if task_obj:
             try:
                 if poller_obj:

--- a/src/listingjet/models/tenant.py
+++ b/src/listingjet/models/tenant.py
@@ -18,8 +18,6 @@ class Tenant(Base):
     stripe_customer_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     stripe_subscription_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     webhook_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
-    # Credit system
-    credit_balance: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
     included_credits: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
     rollover_cap: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
     preferred_language: Mapped[str] = mapped_column(String(10), default="en", server_default="en")

--- a/src/listingjet/models/tenant_health_weights.py
+++ b/src/listingjet/models/tenant_health_weights.py
@@ -1,0 +1,25 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import UUID, DateTime, Float, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from listingjet.database import Base
+
+
+class TenantHealthWeights(Base):
+    """Per-tenant custom health score weights (Enterprise/Team only)."""
+
+    __tablename__ = "tenant_health_weights"
+    __table_args__ = (UniqueConstraint("tenant_id", name="uq_thw_tenant"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    media: Mapped[float] = mapped_column(Float, nullable=False, default=0.30)
+    content: Mapped[float] = mapped_column(Float, nullable=False, default=0.20)
+    velocity: Mapped[float] = mapped_column(Float, nullable=False, default=0.15)
+    syndication: Mapped[float] = mapped_column(Float, nullable=False, default=0.20)
+    market: Mapped[float] = mapped_column(Float, nullable=False, default=0.15)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )

--- a/src/listingjet/models/user.py
+++ b/src/listingjet/models/user.py
@@ -27,4 +27,6 @@ class User(Base):
     role: Mapped[UserRole] = mapped_column(SAEnum(UserRole, values_callable=lambda x: [e.value for e in x]), default=UserRole.OPERATOR)
     consent_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     consent_version: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    ai_consent_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    ai_consent_version: Mapped[str | None] = mapped_column(String(20), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/src/listingjet/services/data_retention.py
+++ b/src/listingjet/services/data_retention.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from listingjet.models.health_score_history import HealthScoreHistory
 from listingjet.models.listing import Listing
 from listingjet.models.outbox import Outbox
 
@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 OUTBOX_RETENTION_DAYS = 30
 EXPORT_RETENTION_DAYS = 90
+HEALTH_HISTORY_RETENTION_DAYS = 90
 
 
 async def cleanup_delivered_outbox(session: AsyncSession) -> int:
@@ -73,11 +75,25 @@ async def cleanup_expired_exports(session: AsyncSession, storage=None) -> dict:
     return {"listings_cleaned": len(listings), "s3_deleted": s3_deleted}
 
 
+async def cleanup_old_health_history(session: AsyncSession) -> int:
+    """Delete health score history rows older than HEALTH_HISTORY_RETENTION_DAYS."""
+    cutoff = datetime.now(timezone.utc) - timedelta(days=HEALTH_HISTORY_RETENTION_DAYS)
+    result = await session.execute(
+        delete(HealthScoreHistory).where(HealthScoreHistory.calculated_at < cutoff)
+    )
+    count = result.rowcount
+    if count:
+        logger.info("data_retention.health_history_cleanup deleted=%d cutoff=%s", count, cutoff.isoformat())
+    return count
+
+
 async def run_all_retention(session: AsyncSession, storage=None) -> dict:
     """Run all retention policies. Call from a scheduled task or management command."""
     outbox_deleted = await cleanup_delivered_outbox(session)
     export_result = await cleanup_expired_exports(session, storage=storage)
+    health_deleted = await cleanup_old_health_history(session)
     return {
         "outbox_deleted": outbox_deleted,
         **export_result,
+        "health_history_deleted": health_deleted,
     }

--- a/src/listingjet/services/field_encryption.py
+++ b/src/listingjet/services/field_encryption.py
@@ -1,0 +1,32 @@
+"""Fernet-based field encryption for sensitive values stored in the database (e.g. IDX API keys)."""
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from listingjet.config import settings
+
+
+def _get_fernet() -> Fernet | None:
+    key = settings.field_encryption_key
+    if not key:
+        return None
+    return Fernet(key.encode())
+
+
+def encrypt(plaintext: str) -> str:
+    """Encrypt a plaintext string. Returns ciphertext. Falls back to plaintext if no key configured."""
+    f = _get_fernet()
+    if f is None:
+        return plaintext
+    return f.encrypt(plaintext.encode()).decode()
+
+
+def decrypt(ciphertext: str) -> str:
+    """Decrypt a ciphertext string. Falls back to returning as-is if no key or decryption fails (plaintext migration)."""
+    f = _get_fernet()
+    if f is None:
+        return ciphertext
+    try:
+        return f.decrypt(ciphertext.encode()).decode()
+    except InvalidToken:
+        # Graceful migration: value was stored before encryption was enabled
+        return ciphertext

--- a/src/listingjet/services/idx_feed_poller.py
+++ b/src/listingjet/services/idx_feed_poller.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from listingjet.models.idx_feed_config import IdxFeedConfig
 from listingjet.models.listing import Listing
 from listingjet.models.performance_event import PerformanceEvent
+from listingjet.services.field_encryption import decrypt
 from listingjet.services.outcome_tracker import ingest_outcome
 from listingjet.services.reso_adapter import RESOAdapter
 
@@ -36,7 +37,7 @@ class IdxFeedPoller:
         try:
             adapter = RESOAdapter(
                 base_url=config.base_url,
-                api_key=config.api_key_encrypted,  # TODO: decrypt in production
+                api_key=decrypt(config.api_key_encrypted),
             )
 
             # Get listings for this tenant that are in delivered state

--- a/src/listingjet/services/market_tracker.py
+++ b/src/listingjet/services/market_tracker.py
@@ -1,0 +1,280 @@
+"""
+Market Tracker — automatic listing performance tracking via ATTOM Data API.
+
+Zero agent setup required. Polls ATTOM's sale history endpoint for all
+delivered listings to track MLS status, DOM, and price changes. Feeds
+data into PerformanceEvent + ListingOutcome (same as IDX feed poller).
+
+Runs as a background task in the FastAPI lifespan alongside the outbox poller.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from listingjet.config import settings
+from listingjet.models.listing import Listing
+from listingjet.models.performance_event import PerformanceEvent
+from listingjet.services.outcome_tracker import ingest_outcome
+
+logger = logging.getLogger(__name__)
+
+# Poll every 6 hours — ATTOM data doesn't update in real-time
+POLL_INTERVAL = 6 * 60 * 60
+# Don't re-check a listing more than once per 24h
+MIN_CHECK_INTERVAL = timedelta(hours=24)
+BATCH_SIZE = 25
+ATTOM_TIMEOUT = 15
+
+
+def _build_address_string(address: dict) -> str | None:
+    """Build a one-line address from listing address dict for ATTOM lookup."""
+    street = address.get("street", "")
+    city = address.get("city", "")
+    state = address.get("state", "")
+    zipcode = address.get("zip", "") or address.get("zipcode", "")
+    if not street:
+        return None
+    parts = [street]
+    if city:
+        parts.append(city)
+    if state:
+        parts.append(state)
+    if zipcode:
+        parts.append(zipcode)
+    return ", ".join(parts)
+
+
+async def _call_attom_sale_history(address: str) -> list[dict]:
+    """Query ATTOM sale history endpoint. Returns list of sale records."""
+    if not settings.attom_api_key:
+        return []
+
+    url = "https://api.gateway.attomdata.com/propertyapi/v1.0.0/property/salehistory"
+    headers = {"apikey": settings.attom_api_key}
+    params = {"address": address}
+
+    try:
+        async with httpx.AsyncClient(timeout=ATTOM_TIMEOUT) as client:
+            resp = await client.get(url, params=params, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+            props = data.get("property", [])
+            if not props:
+                return []
+            # salehistory returns sales nested under the property
+            return props[0].get("saleHistory", []) or []
+    except Exception:
+        logger.warning("market_tracker.attom_call_failed address=%s", address[:60])
+        return []
+
+
+async def _call_attom_detail(address: str) -> dict | None:
+    """Query ATTOM basic profile for current listing status/price."""
+    if not settings.attom_api_key:
+        return None
+
+    url = "https://api.gateway.attomdata.com/propertyapi/v1.0.0/property/basicprofile"
+    headers = {"apikey": settings.attom_api_key}
+    params = {"address": address}
+
+    try:
+        async with httpx.AsyncClient(timeout=ATTOM_TIMEOUT) as client:
+            resp = await client.get(url, params=params, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+            props = data.get("property", [])
+            return props[0] if props else None
+    except Exception:
+        logger.warning("market_tracker.attom_detail_failed address=%s", address[:60])
+        return None
+
+
+def _translate_attom_to_idx(detail: dict | None, sale_history: list[dict]) -> dict:
+    """Translate ATTOM response into the idx_data format expected by ingest_outcome."""
+    result: dict = {}
+
+    if detail:
+        sale = detail.get("sale", {}) or {}
+        amount = sale.get("amount", {}) or {}
+
+        # Current listing price
+        list_price = amount.get("saleamt")
+        if list_price:
+            result["ListPrice"] = float(list_price)
+
+        # Sale status from ATTOM
+        sale_type = str(sale.get("saletype", "")).lower()
+        if sale_type in ("closed", "sold"):
+            result["StandardStatus"] = "Closed"
+            result["ClosePrice"] = float(list_price) if list_price else None
+        elif sale_type in ("pending", "under contract"):
+            result["StandardStatus"] = "Pending"
+        elif sale_type in ("active", "listed"):
+            result["StandardStatus"] = "Active"
+
+        # Sale date for DOM calculation
+        sale_date_str = sale.get("salerecdate") or sale.get("saletransdate")
+        if sale_date_str:
+            result["_sale_date"] = sale_date_str
+
+    # Most recent sale from history (often has close price / sold price)
+    if sale_history:
+        latest = sale_history[0]
+        amt = latest.get("amount", {}) or {}
+        sold_price = amt.get("saleamt")
+        if sold_price and "ClosePrice" not in result:
+            result["ClosePrice"] = float(sold_price)
+            result["SoldPrice"] = float(sold_price)
+
+        sale_date = latest.get("salerecdate") or latest.get("saletransdate")
+        if sale_date and "StandardStatus" not in result:
+            # If there's a recent sale record, it's likely closed
+            result["StandardStatus"] = "Closed"
+
+    return result
+
+
+async def _check_listing(session: AsyncSession, listing: Listing) -> bool:
+    """Check a single listing against ATTOM. Returns True if data was recorded."""
+    address = listing.address or {}
+    address_str = _build_address_string(address)
+    if not address_str:
+        return False
+
+    detail, sale_history = await asyncio.gather(
+        _call_attom_detail(address_str),
+        _call_attom_sale_history(address_str),
+    )
+
+    if detail is None and not sale_history:
+        return False
+
+    idx_data = _translate_attom_to_idx(detail, sale_history)
+    if not idx_data:
+        return False
+
+    now = datetime.now(timezone.utc)
+
+    # Record status change
+    status_str = idx_data.get("StandardStatus", "")
+    status_val = {"Active": 1.0, "Pending": 2.0, "Closed": 3.0}.get(status_str, 0.0)
+    if status_val:
+        session.add(PerformanceEvent(
+            tenant_id=listing.tenant_id,
+            listing_id=listing.id,
+            signal_type="market.status_change",
+            value=status_val,
+            source="attom",
+            recorded_at=now,
+        ))
+
+    # Record price
+    list_price = idx_data.get("ListPrice")
+    if list_price is not None:
+        last_price_result = await session.execute(
+            select(PerformanceEvent)
+            .where(
+                PerformanceEvent.listing_id == listing.id,
+                PerformanceEvent.signal_type.in_(["market.price_change", "idx.price_change"]),
+            )
+            .order_by(PerformanceEvent.recorded_at.desc())
+            .limit(1)
+        )
+        last = last_price_result.scalar_one_or_none()
+        if last is None or last.value != float(list_price):
+            session.add(PerformanceEvent(
+                tenant_id=listing.tenant_id,
+                listing_id=listing.id,
+                signal_type="market.price_change",
+                value=float(list_price),
+                source="attom",
+                recorded_at=now,
+            ))
+
+    # Ingest outcome when Pending or Closed
+    if status_str in ("Pending", "Closed"):
+        try:
+            await ingest_outcome(
+                session=session,
+                listing_id=listing.id,
+                tenant_id=listing.tenant_id,
+                idx_data=idx_data,
+                source="attom",
+            )
+        except Exception:
+            logger.warning("market_tracker.outcome_ingest_failed listing=%s", listing.id)
+
+    return True
+
+
+class MarketTracker:
+    """Background task that tracks delivered listing performance via ATTOM."""
+
+    def __init__(self, session_factory, poll_interval: int = POLL_INTERVAL):
+        self._session_factory = session_factory
+        self._poll_interval = poll_interval
+        self._running = False
+        # Track when each listing was last checked
+        self._last_checked: dict[str, datetime] = {}
+
+    async def _process_batch(self, session: AsyncSession) -> int:
+        """Find delivered listings due for checking and process them."""
+        if not settings.attom_api_key:
+            return 0
+
+        now = datetime.now(timezone.utc)
+
+        result = await session.execute(
+            select(Listing).where(
+                Listing.state == "delivered",
+            ).limit(BATCH_SIZE * 2)  # fetch extra, filter by last-checked in memory
+        )
+        listings = result.scalars().all()
+
+        checked = 0
+        for listing in listings:
+            lid = str(listing.id)
+            last = self._last_checked.get(lid)
+            if last and (now - last) < MIN_CHECK_INTERVAL:
+                continue
+
+            updated = await _check_listing(session, listing)
+            self._last_checked[lid] = now
+            if updated:
+                checked += 1
+
+            if checked >= BATCH_SIZE:
+                break
+
+        if checked:
+            await session.flush()
+            logger.info("market_tracker.batch_complete checked=%d", checked)
+
+        return checked
+
+    async def run(self):
+        """Long-running poll loop. Call from FastAPI lifespan."""
+        if not settings.attom_api_key:
+            logger.info("market_tracker.disabled — no ATTOM_API_KEY configured")
+            return
+
+        self._running = True
+        logger.info("market_tracker.started poll_interval=%ds", self._poll_interval)
+
+        while self._running:
+            try:
+                async with self._session_factory() as session:
+                    async with session.begin():
+                        await self._process_batch(session)
+            except Exception:
+                logger.exception("market_tracker.error")
+            await asyncio.sleep(self._poll_interval)
+
+    def stop(self):
+        self._running = False

--- a/tests/test_agents/test_video.py
+++ b/tests/test_agents/test_video.py
@@ -184,9 +184,13 @@ def test_select_photos_fills_12_positions():
     assert selected[0][2].room_label == "exterior"
     # pos 12 = drone
     assert selected[-1][2].room_label == "drone"
-    # Interior slots 3-11 should be score-descending
-    interior_scores = [s[2].quality_score for s in selected[2:11]]
-    assert interior_scores == sorted(interior_scores, reverse=True)
+    # Interior slots 3-11 should follow walkthrough order (spatial flow)
+    interior_rooms = [s[2].room_label for s in selected[2:11]]
+    assert interior_rooms == [
+        "living_room", "kitchen", "dining_room", "office",
+        "primary_bedroom", "primary_bathroom", "bedroom", "bathroom",
+        "backyard",
+    ]
 
 
 def test_select_photos_pads_when_thin():

--- a/tests/test_api/test_webhook_credits.py
+++ b/tests/test_api/test_webhook_credits.py
@@ -27,11 +27,12 @@ async def _create_tenant(db: AsyncSession, **overrides) -> Tenant:
         plan="pro",
         stripe_customer_id=f"cus_{uuid.uuid4().hex[:8]}",
         stripe_subscription_id=f"sub_{uuid.uuid4().hex[:8]}",
-        credit_balance=20,
+        initial_balance=20,
         included_credits=50,
         rollover_cap=25,
     )
     defaults.update(overrides)
+    initial_balance = defaults.pop("initial_balance", 0)
     tenant = Tenant(**defaults)
     db.add(tenant)
     await db.flush()
@@ -39,7 +40,7 @@ async def _create_tenant(db: AsyncSession, **overrides) -> Tenant:
     # Also create a CreditAccount so the credit service can find it
     credit_account = CreditAccount(
         tenant_id=tenant.id,
-        balance=defaults.get("credit_balance", 0),
+        balance=initial_balance,
         rollover_cap=defaults.get("rollover_cap", 0),
     )
     db.add(credit_account)
@@ -131,7 +132,9 @@ async def test_webhook_subscription_deleted_preserves_credits(async_client: Asyn
     t = await _get_tenant(db_session, tenant.id)
     assert t.plan == "free"
     assert t.included_credits == 0
-    assert t.credit_balance == 20  # preserved
+    # Credits live in CreditAccount, not Tenant
+    acct = await _get_credit_account(db_session, tenant.id)
+    assert acct.balance == 20  # preserved
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration/test_credit_lifecycle.py
+++ b/tests/test_integration/test_credit_lifecycle.py
@@ -21,6 +21,8 @@ async def _register(client: AsyncClient, plan_tier: str = "active_agent") -> tup
         "name": "E2E Agent",
         "company_name": "E2E Realty",
         "plan_tier": plan_tier,
+        "consent": True,
+        "ai_consent": True,
     })
     assert resp.status_code == 200, resp.text
     token = resp.json()["access_token"]
@@ -330,6 +332,8 @@ async def test_api_contracts_auth(async_client: AsyncClient):
     resp = await async_client.post("/auth/register", json={
         "email": email, "password": "StrongPass1!", "name": "Contract Test", "company_name": "Test Co",
         "plan_tier": "free",
+        "consent": True,
+        "ai_consent": True,
     })
     assert resp.status_code == 200
     body = resp.json()
@@ -442,3 +446,123 @@ async def test_api_contracts_unauthenticated(async_client: AsyncClient):
         else:
             resp = await async_client.post(path, json={})
         assert resp.status_code in (401, 403, 422), f"{method} {path} returned {resp.status_code}"
+
+
+# ── Test: AI Consent Required for Registration ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_ai_consent_blocks_pipeline(async_client: AsyncClient, db_session):
+    """User who opts out of AI consent can register but can't start pipeline."""
+    email = f"no-ai-{uuid.uuid4().hex[:8]}@test.com"
+    resp = await async_client.post("/auth/register", json={
+        "email": email,
+        "password": "StrongPass1!",
+        "name": "No AI",
+        "company_name": "TestCo",
+        "plan_tier": "active_agent",
+        "consent": True,
+        "ai_consent": False,
+    })
+    assert resp.status_code == 200
+    token = resp.json()["access_token"]
+    me = await async_client.get("/auth/me", headers=_auth(token))
+    tenant_id = me.json()["tenant_id"]
+
+    await _add_credits(async_client, db_session, tenant_id, 50)
+
+    # Create listing + assets
+    listing_id = await _create_listing(async_client, token)
+    await async_client.post(f"/listings/{listing_id}/assets", json={
+        "assets": [{"file_path": "s3://b/p.jpg", "file_hash": "abc"}],
+    }, headers=_auth(token))
+
+    # Pipeline start should be blocked
+    resp = await async_client.post(f"/listings/{listing_id}/start-pipeline", json={
+        "selected_addons": [],
+    }, headers=_auth(token))
+    assert resp.status_code == 403
+    assert "consent" in resp.json()["detail"].lower()
+
+
+# ── Test: AI Consent Toggle ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ai_consent_toggle(async_client: AsyncClient):
+    """User can grant and revoke AI processing consent."""
+    token, _ = await _register(async_client)
+
+    # Revoke consent
+    resp = await async_client.post("/auth/ai-consent", json={"consent": False}, headers=_auth(token))
+    assert resp.status_code == 200
+    assert resp.json()["ai_consent"] is False
+
+    # Re-grant consent
+    resp = await async_client.post("/auth/ai-consent", json={"consent": True}, headers=_auth(token))
+    assert resp.status_code == 200
+    assert resp.json()["ai_consent"] is True
+
+
+# ── Test: Pipeline Start + Asset Upload E2E ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_listing_create_upload_start(async_client: AsyncClient, db_session):
+    """Full flow: register → create listing → upload assets → start pipeline."""
+    token, tenant_id = await _register(async_client, plan_tier="active_agent")
+    await _add_credits(async_client, db_session, tenant_id, 50)
+
+    # Create listing
+    listing_id = await _create_listing(async_client, token)
+
+    # Register assets
+    resp = await async_client.post(f"/listings/{listing_id}/assets", json={
+        "assets": [
+            {"file_path": f"s3://bucket/{listing_id}/photo_{i}.jpg", "file_hash": f"hash{i:03d}"}
+            for i in range(5)
+        ],
+    }, headers=_auth(token))
+    assert resp.status_code in (200, 201)
+
+    # Start pipeline
+    resp = await async_client.post(f"/listings/{listing_id}/start-pipeline", json={
+        "selected_addons": [],
+    }, headers=_auth(token))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["state"] == "uploading"
+    assert "workflow_id" in body
+
+
+# ── Test: Admin Tenant + Credit Management E2E ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_admin_tenant_credit_flow(async_client: AsyncClient, db_session):
+    """Admin registers → promotes to superadmin → manages tenant credits."""
+    from tests.conftest import promote_to_superadmin
+
+    token, tenant_id = await _register(async_client, plan_tier="free")
+    await promote_to_superadmin(async_client, token)
+
+    # View tenant credits
+    resp = await async_client.get(f"/admin/tenants/{tenant_id}/credits", headers=_auth(token))
+    assert resp.status_code == 200
+    assert resp.json()["credit_balance"] >= 0
+
+    # Adjust credits
+    resp = await async_client.post(
+        f"/admin/tenants/{tenant_id}/credits/adjust",
+        json={"amount": 100, "reason": "E2E test bonus"},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["balance_after"] >= 100
+
+    # Verify in tenant list
+    resp = await async_client.get("/admin/tenants", headers=_auth(token))
+    assert resp.status_code == 200
+    tenants = resp.json()["items"]
+    tenant = next(t for t in tenants if t["id"] == tenant_id)
+    assert tenant["credit_balance"] >= 100


### PR DESCRIPTION
## Summary

Continuation of #196 (already merged). Three features that were pushed after the initial merge:

- **Custom health weights persistence** — `TenantHealthWeights` model + migration 047. PATCH /settings/health-weights now saves to DB. HealthScoreAgent loads custom weights in pipeline. Team/Enterprise only.
- **AI processing consent management** — `ai_consent_at`/`ai_consent_version` on User model. Pipeline start returns 403 if consent missing. POST /auth/ai-consent to toggle. Migration 048 backfills existing users. Defaults to opt-in (opt-out model).
- **E2E integration tests** — 4 new tests: consent-blocks-pipeline, consent-toggle, listing-create-upload-start, admin-credit-flow.

## Test plan

- [ ] `alembic upgrade head` — migrations 047 + 048 apply cleanly
- [ ] PATCH /settings/health-weights persists and GET reads back custom weights
- [ ] Non-team plan gets 403 on PATCH /settings/health-weights
- [ ] Registration with ai_consent=false → pipeline start returns 403
- [ ] POST /auth/ai-consent toggles consent on/off
- [ ] All new E2E tests pass

https://claude.ai/code/session_01M3WoqpcMoqXYeL1eizQKS2