### PR TITLE
fix(tests): mock get_temporal_client in listings_draft module

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,7 @@ def _mock_external_services():
         patch("listingjet.temporal_client.get_temporal_client", return_value=mock_temporal),
         patch("listingjet.api.listings_media.get_temporal_client", return_value=mock_temporal),
         patch("listingjet.api.listings_workflow.get_temporal_client", return_value=mock_temporal),
+        patch("listingjet.api.listings_draft.get_temporal_client", return_value=mock_temporal),
         patch("listingjet.api.bulk.get_temporal_client", return_value=mock_temporal),
     ):
         yield


### PR DESCRIPTION
## Summary

Fixes the broken `test` job on `main` (since #197 landed). One-line addition to `tests/conftest.py` mock patch list — scoped, reviewable, independent of any open feature PR.

## Root cause

PR #197 added `tests/test_integration/test_credit_lifecycle.py::test_listing_create_upload_start`, which is the first test to exercise `POST /listings/{id}/start-pipeline`. That endpoint lives in `src/listingjet/api/listings_draft.py`, which imports the Temporal client at module load:

```python
from listingjet.temporal_client import get_temporal_client
```

That `from … import` creates a new name binding inside `listings_draft`. The autouse Temporal mock in `tests/conftest.py` already patches `temporal_client`, `listings_media`, `listings_workflow`, and `bulk` — but it never patched `listings_draft`, so `listings_draft.get_temporal_client` stayed bound to the real function.

In CI, no Temporal server runs, so the endpoint hit `Client.connect("localhost:7233", …)`, threw, and the endpoint's catch-all returned 500. The test assertion `assert resp.status_code == 200` produced the `assert 500 == 200` failure reported on every main-branch CI run since #197.

## The fix

```diff
         patch("listingjet.api.listings_media.get_temporal_client", return_value=mock_temporal),
         patch("listingjet.api.listings_workflow.get_temporal_client", return_value=mock_temporal),
+        patch("listingjet.api.listings_draft.get_temporal_client", return_value=mock_temporal),
         patch("listingjet.api.bulk.get_temporal_client", return_value=mock_temporal),
```

One line. No production code changes. Matches the existing mocking pattern for sibling modules.

## Test plan

- [ ] CI `test` job goes green on this PR
- [ ] After merge, rebase #198 (`fix/design-audit-criticals`) onto main and its `test` job also goes green
- [ ] Any future endpoint module that calls `get_temporal_client` via `from … import` needs the same conftest entry — candidate for a future refactor to a single dotted-path fixture