### PR TITLE
fix: virtual staging and image edits now actually see the input photo

### DIFF
--- a/src/listingjet/agents/virtual_staging.py
+++ b/src/listingjet/agents/virtual_staging.py
@@ -7,7 +7,6 @@ staged with the selected style, downloaded, and re-uploaded to S3.
 import logging
 import uuid
 
-import httpx
 from sqlalchemy import select
 
 from listingjet.database import AsyncSessionLocal
@@ -78,21 +77,15 @@ class VirtualStagingAgent(BaseAgent):
                     # Get presigned URL for the source image
                     source_url = self._storage.presigned_url(asset.file_path)
 
-                    # Call staging provider
-                    staged_url = await self._provider.stage_image(
+                    # Call staging provider — returns PNG bytes directly
+                    staged_bytes = await self._provider.stage_image(
                         image_url=source_url,
                         room_type=vr.room_label,
                         style=_DEFAULT_STYLE,
                     )
 
-                    # Download staged image and upload to S3
-                    async with httpx.AsyncClient(timeout=60) as client:
-                        resp = await client.get(staged_url)
-                        resp.raise_for_status()
-                        staged_bytes = resp.content
-
-                    s3_key = f"listings/{listing_id}/staged/{uuid.uuid4()}.jpg"
-                    self._storage.upload(s3_key, staged_bytes, content_type="image/jpeg")
+                    s3_key = f"listings/{listing_id}/staged/{uuid.uuid4()}.png"
+                    self._storage.upload(s3_key, staged_bytes, content_type="image/png")
 
                     # Create a new asset for the staged version
                     staged_asset = Asset(

--- a/src/listingjet/providers/_openai_edits.py
+++ b/src/listingjet/providers/_openai_edits.py
@@ -1,0 +1,113 @@
+"""Shared helper for OpenAI image-to-image calls.
+
+Both OpenAIVirtualStagingProvider and OpenAIImageEditProvider delegate to
+edit_single_image() so they get real image-conditioned edits (via the
+/v1/images/edits endpoint with gpt-image-1.5) instead of the DALL-E 3
+text-only generations endpoint.
+"""
+from __future__ import annotations
+
+import base64
+import logging
+
+import httpx
+
+from listingjet.services.metrics import record_provider_call, record_token_usage
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://api.openai.com/v1"
+_EDITS_ENDPOINT = f"{_BASE_URL}/images/edits"
+
+DEFAULT_MODEL = "gpt-image-1.5"
+DEFAULT_SIZE = "1536x1024"
+DEFAULT_QUALITY = "medium"
+
+_DOWNLOAD_TIMEOUT = 30.0
+_EDIT_TIMEOUT = 180.0
+
+
+class OpenAIEditError(RuntimeError):
+    """Raised when an OpenAI image edit call fails."""
+
+
+async def fetch_image_bytes(url: str) -> tuple[bytes, str]:
+    """Download bytes from a URL, return (content, content_type)."""
+    async with httpx.AsyncClient(timeout=_DOWNLOAD_TIMEOUT) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        content_type = resp.headers.get("content-type", "image/png").split(";")[0].strip()
+        return resp.content, content_type
+
+
+async def edit_single_image(
+    *,
+    api_key: str,
+    image_bytes: bytes,
+    image_content_type: str,
+    prompt: str,
+    provider_label: str,
+    model: str = DEFAULT_MODEL,
+    size: str = DEFAULT_SIZE,
+    quality: str = DEFAULT_QUALITY,
+) -> bytes:
+    """Send a single input image + prompt to /v1/images/edits and return PNG bytes.
+
+    provider_label is used for metrics attribution (e.g. "openai_staging",
+    "openai_image_edit").
+    """
+    if not api_key:
+        raise OpenAIEditError("OPENAI_API_KEY is not configured")
+    if not image_bytes:
+        raise OpenAIEditError("image_bytes must be non-empty")
+
+    filename = "input.png" if image_content_type == "image/png" else "input.jpg"
+    files = [("image[]", (filename, image_bytes, image_content_type))]
+    data = {
+        "model": model,
+        "prompt": prompt,
+        "size": size,
+        "quality": quality,
+        "n": "1",
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=_EDIT_TIMEOUT) as client:
+            resp = await client.post(
+                _EDITS_ENDPOINT,
+                headers={"Authorization": f"Bearer {api_key}"},
+                data=data,
+                files=files,
+            )
+            resp.raise_for_status()
+            body = resp.json()
+    except httpx.HTTPStatusError as exc:
+        detail = exc.response.text[:500]
+        record_provider_call(provider_label, False)
+        raise OpenAIEditError(
+            f"OpenAI images/edits returned {exc.response.status_code}: {detail}"
+        ) from exc
+    except httpx.HTTPError as exc:
+        record_provider_call(provider_label, False)
+        raise OpenAIEditError(f"OpenAI images/edits network error: {exc}") from exc
+
+    try:
+        b64 = body["data"][0]["b64_json"]
+    except (KeyError, IndexError) as exc:
+        record_provider_call(provider_label, False)
+        raise OpenAIEditError(f"Unexpected response shape: {body}") from exc
+
+    usage = body.get("usage") or {}
+    if usage:
+        input_tokens = int(usage.get("input_tokens", 0))
+        output_tokens = int(usage.get("output_tokens", 0))
+        if input_tokens or output_tokens:
+            record_token_usage(provider_label, input_tokens, output_tokens)
+
+    record_provider_call(provider_label, True)
+    png_bytes = base64.b64decode(b64)
+    logger.info(
+        "%s.edit_single_image model=%s size=%s quality=%s bytes=%d",
+        provider_label, model, size, quality, len(png_bytes),
+    )
+    return png_bytes

--- a/src/listingjet/providers/base.py
+++ b/src/listingjet/providers/base.py
@@ -81,7 +81,7 @@ class VirtualStagingProvider(ABC):
         image_url: str,
         room_type: str,
         style: str = "modern",
-    ) -> str:
+    ) -> bytes:
         """Transform an empty/unfurnished room photo into a staged version.
 
         Args:
@@ -90,7 +90,7 @@ class VirtualStagingProvider(ABC):
             style: Staging style (modern, contemporary, minimalist, coastal, etc.)
 
         Returns:
-            URL of the staged image.
+            Raw PNG/JPEG bytes of the staged image.
         """
         ...
 

--- a/src/listingjet/providers/mock.py
+++ b/src/listingjet/providers/mock.py
@@ -148,8 +148,8 @@ class MockImageEditProvider(ImageEditProvider):
 class MockVirtualStagingProvider(VirtualStagingProvider):
     provider_name = "mock"
 
-    async def stage_image(self, image_url: str, room_type: str, style: str = "modern") -> str:
-        return f"s3://listingjet-dev/staged/{room_type}-{style}-mock.jpg"
+    async def stage_image(self, image_url: str, room_type: str, style: str = "modern") -> bytes:
+        return b"\xff\xd8\xff\xe0mock-staged-jpeg-" + f"{room_type}-{style}".encode()
 
 
 class MockTemplateProvider(TemplateProvider):

--- a/src/listingjet/providers/openai_image_edit.py
+++ b/src/listingjet/providers/openai_image_edit.py
@@ -1,97 +1,98 @@
 """OpenAI image editing provider — object removal and enhancement.
 
-Uses GPT-4V for understanding + DALL-E for inpainting/editing.
+Uses gpt-image-1.5 via /v1/images/edits so the model actually looks at the
+input image (unlike DALL-E 3's text-only /v1/images/generations endpoint).
 """
-import logging
+from __future__ import annotations
 
-import httpx
+import logging
 
 from listingjet.config import settings
 
+from ._openai_edits import (
+    OpenAIEditError,
+    edit_single_image,
+    fetch_image_bytes,
+)
 from .base import ImageEditProvider
 
 logger = logging.getLogger(__name__)
 
 
+_ENHANCEMENT_PROMPTS = {
+    "brighten": (
+        "Keep this exact same real estate photo but brighten the scene as if "
+        "it was shot during golden-hour natural sunlight. Preserve the room "
+        "layout, architecture, furniture, and finishes exactly as shown. "
+        "Balanced exposure, warm tones, crisp shadows, no blown highlights."
+    ),
+    "fix_lighting": (
+        "Rebalance the lighting in this real estate photo so exposure is even "
+        "across the frame, shadows are softened, and white balance reads "
+        "neutral-warm. Preserve the room layout, architecture, furniture, "
+        "and finishes exactly as shown. No HDR halos, no blown highlights."
+    ),
+    "improve_quality": (
+        "Upscale and sharpen this real estate photo to magazine quality while "
+        "preserving the room layout, architecture, furniture, and finishes "
+        "exactly as shown. Natural colors, no filters, no over-processing."
+    ),
+    "declutter": (
+        "Remove personal items, clutter, stray objects, and visual noise from "
+        "this real estate photo. Preserve the room layout, architecture, "
+        "walls, flooring, and primary furniture exactly as shown. Surfaces "
+        "should look clean and styled, not repainted."
+    ),
+}
+
+
 class OpenAIImageEditProvider(ImageEditProvider):
-    """Image editor using OpenAI's image generation API."""
+    """Image editor using gpt-image-1.5 via /v1/images/edits."""
 
     provider_name = "openai"
 
     def __init__(self, api_key: str | None = None):
         self._api_key = api_key or settings.openai_api_key
-        self._base_url = "https://api.openai.com/v1"
 
     async def remove_object(self, image_url: str, object_description: str) -> bytes:
-        """Remove an object by generating a clean version of the image.
-
-        Uses DALL-E 3 to regenerate the image area without the specified object.
-        """
+        """Remove an object from a real estate photo while preserving the rest."""
         prompt = (
-            f"A clean, professional real estate listing photo. "
-            f"The image should look exactly like the original photo but with "
-            f"the {object_description} completely removed. "
-            f"Fill the area naturally with the surrounding background. "
-            f"Photorealistic, high quality, no artifacts."
+            f"Remove the {object_description} from this real estate photo. "
+            f"Preserve the room layout, architecture, furniture, lighting, "
+            f"and finishes exactly as shown. Fill the area where the "
+            f"{object_description} was with a natural continuation of the "
+            f"surrounding background — walls, floor, ceiling, or whatever is "
+            f"adjacent. Photorealistic, no artifacts, no warping."
         )
 
-        async with httpx.AsyncClient(timeout=90) as client:
-            response = await client.post(
-                f"{self._base_url}/images/generations",
-                headers={"Authorization": f"Bearer {self._api_key}"},
-                json={
-                    "model": "dall-e-3",
-                    "prompt": prompt,
-                    "n": 1,
-                    "size": "1792x1024",
-                    "quality": "hd",
-                    "response_format": "url",
-                },
+        try:
+            image_bytes, content_type = await fetch_image_bytes(image_url)
+            result = await edit_single_image(
+                api_key=self._api_key,
+                image_bytes=image_bytes,
+                image_content_type=content_type,
+                prompt=prompt,
+                provider_label="openai_image_edit",
             )
-            response.raise_for_status()
-            data = response.json()
-            result_url = data["data"][0]["url"]
-
-            # Download the generated image
-            img_resp = await client.get(result_url)
-            img_resp.raise_for_status()
-
+        except OpenAIEditError:
+            raise
         logger.info("image_edit.remove object=%s", object_description)
-        return img_resp.content
+        return result
 
     async def enhance(self, image_url: str, enhancement: str) -> bytes:
-        """Enhance an image using DALL-E.
+        """Enhance an image — brighten, fix_lighting, improve_quality, declutter."""
+        prompt = _ENHANCEMENT_PROMPTS.get(enhancement, _ENHANCEMENT_PROMPTS["improve_quality"])
 
-        Supported enhancements: brighten, fix_lighting, improve_quality, declutter
-        """
-        enhancement_prompts = {
-            "brighten": "A bright, well-lit version of this real estate photo with natural sunlight streaming in, warm tones, and clear visibility of all details. Professional real estate photography.",
-            "fix_lighting": "A professionally lit version of this real estate photo with balanced exposure, no harsh shadows, warm white balance, and clear details in all areas. Professional HDR real estate photography.",
-            "improve_quality": "A high-resolution, professional-grade version of this real estate photo with sharp details, perfect white balance, vibrant but natural colors, and magazine-quality composition.",
-            "declutter": "A clean, tidy version of this real estate photo with personal items, clutter, and mess removed. Surfaces are clear, rooms look spacious and move-in ready. Photorealistic.",
-        }
-
-        prompt = enhancement_prompts.get(enhancement, enhancement_prompts["improve_quality"])
-
-        async with httpx.AsyncClient(timeout=90) as client:
-            response = await client.post(
-                f"{self._base_url}/images/generations",
-                headers={"Authorization": f"Bearer {self._api_key}"},
-                json={
-                    "model": "dall-e-3",
-                    "prompt": prompt,
-                    "n": 1,
-                    "size": "1792x1024",
-                    "quality": "hd",
-                    "response_format": "url",
-                },
+        try:
+            image_bytes, content_type = await fetch_image_bytes(image_url)
+            result = await edit_single_image(
+                api_key=self._api_key,
+                image_bytes=image_bytes,
+                image_content_type=content_type,
+                prompt=prompt,
+                provider_label="openai_image_edit",
             )
-            response.raise_for_status()
-            data = response.json()
-            result_url = data["data"][0]["url"]
-
-            img_resp = await client.get(result_url)
-            img_resp.raise_for_status()
-
+        except OpenAIEditError:
+            raise
         logger.info("image_edit.enhance type=%s", enhancement)
-        return img_resp.content
+        return result

--- a/src/listingjet/providers/openai_staging.py
+++ b/src/listingjet/providers/openai_staging.py
@@ -1,62 +1,74 @@
-"""OpenAI DALL-E virtual staging provider.
+"""OpenAI virtual staging provider.
 
-Uses DALL-E 3 image editing to stage empty rooms with furniture.
-Falls back gracefully if the image can't be processed.
+Uses gpt-image-1.5 via /v1/images/edits so the model actually looks at the
+empty room photo (unlike DALL-E 3's text-only generations endpoint). Returns
+raw PNG bytes of the staged version.
 """
-import logging
+from __future__ import annotations
 
-import httpx
+import logging
 
 from listingjet.config import settings
 
+from ._openai_edits import (
+    OpenAIEditError,
+    edit_single_image,
+    fetch_image_bytes,
+)
 from .base import VirtualStagingProvider
 
 logger = logging.getLogger(__name__)
 
-_STAGING_PROMPTS = {
-    "modern": "A beautifully staged {room} with modern furniture, clean lines, neutral tones, and natural light. Photorealistic interior design photography.",
-    "contemporary": "A stylish staged {room} with contemporary furniture, warm wood accents, statement lighting, and curated art. Photorealistic.",
-    "minimalist": "A minimalist staged {room} with essential furniture only, white walls, simple lines, and open space. Photorealistic.",
-    "coastal": "A bright coastal-styled staged {room} with light wood furniture, blue accents, woven textures, and ocean-inspired decor. Photorealistic.",
-    "traditional": "A classically staged {room} with traditional furniture, rich wood tones, elegant fabrics, and warm lighting. Photorealistic.",
-    "luxury": "A luxuriously staged {room} with high-end designer furniture, marble accents, crystal lighting, and premium finishes. Photorealistic.",
+_STAGING_STYLE_DESCRIPTIONS = {
+    "modern": "modern furniture with clean lines, neutral tones, and natural light",
+    "contemporary": "contemporary furniture with warm wood accents, statement lighting, and curated art",
+    "minimalist": "minimalist furniture only, white walls, simple lines, and open space",
+    "coastal": "light wood furniture, blue accents, woven textures, and coastal-inspired decor",
+    "traditional": "traditional furniture with rich wood tones, elegant fabrics, and warm lighting",
+    "luxury": "high-end designer furniture, marble accents, crystal lighting, and premium finishes",
 }
 
 
+def _build_prompt(room_type: str, style: str) -> str:
+    room_display = room_type.replace("_", " ")
+    style_desc = _STAGING_STYLE_DESCRIPTIONS.get(
+        style, _STAGING_STYLE_DESCRIPTIONS["modern"]
+    )
+    return (
+        f"Stage this empty {room_display} photo with {style_desc}. "
+        f"Preserve the exact room layout, walls, floors, ceiling, windows, "
+        f"doors, and architectural details shown in the photo. Only add the "
+        f"furniture and decor — do not change the room itself. Photorealistic "
+        f"real estate photography, natural lighting consistent with the "
+        f"original photo, no warping or architectural modifications."
+    )
+
+
 class OpenAIVirtualStagingProvider(VirtualStagingProvider):
-    """Stage rooms using OpenAI's image generation API."""
+    """Stage empty rooms using gpt-image-1.5 via /v1/images/edits."""
 
     provider_name = "openai"
 
     def __init__(self, api_key: str | None = None):
         self._api_key = api_key or settings.openai_api_key
-        self._base_url = "https://api.openai.com/v1"
 
     async def stage_image(
         self,
         image_url: str,
         room_type: str,
         style: str = "modern",
-    ) -> str:
-        prompt_template = _STAGING_PROMPTS.get(style, _STAGING_PROMPTS["modern"])
-        room_display = room_type.replace("_", " ")
-        prompt = prompt_template.format(room=room_display)
-
-        async with httpx.AsyncClient(timeout=90) as client:
-            response = await client.post(
-                f"{self._base_url}/images/generations",
-                headers={"Authorization": f"Bearer {self._api_key}"},
-                json={
-                    "model": "dall-e-3",
-                    "prompt": f"Transform this empty {room_display} photo into: {prompt}",
-                    "n": 1,
-                    "size": "1792x1024",
-                    "quality": "hd",
-                },
+    ) -> bytes:
+        prompt = _build_prompt(room_type, style)
+        try:
+            image_bytes, content_type = await fetch_image_bytes(image_url)
+            result = await edit_single_image(
+                api_key=self._api_key,
+                image_bytes=image_bytes,
+                image_content_type=content_type,
+                prompt=prompt,
+                provider_label="openai_staging",
             )
-            response.raise_for_status()
-            data = response.json()
-
-        image_url_result = data["data"][0]["url"]
-        logger.info("openai_staging room=%s style=%s", room_type, style)
-        return image_url_result
+        except OpenAIEditError:
+            raise
+        logger.info("openai_staging.staged room=%s style=%s", room_type, style)
+        return result

--- a/tests/test_providers/test_openai_edits.py
+++ b/tests/test_providers/test_openai_edits.py
@@ -1,0 +1,264 @@
+"""Tests for the shared OpenAI image-edits helper and the two providers
+that delegate to it (OpenAIVirtualStagingProvider, OpenAIImageEditProvider).
+
+These tests verify the pieces that were previously broken: both providers
+used to call /v1/images/generations (text-only) so they never actually saw
+the input image. The fix switches them to /v1/images/edits with
+gpt-image-1.5 and passes the input image as multipart form data.
+"""
+import base64
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from listingjet.providers._openai_edits import (
+    OpenAIEditError,
+    edit_single_image,
+    fetch_image_bytes,
+)
+from listingjet.providers.openai_image_edit import OpenAIImageEditProvider
+from listingjet.providers.openai_staging import OpenAIVirtualStagingProvider
+
+_FAKE_PNG = b"\x89PNG\r\n\x1a\n" + b"0" * 256
+_FAKE_B64 = base64.b64encode(_FAKE_PNG).decode()
+
+
+# ---------- helper: edit_single_image ----------
+
+
+@pytest.mark.asyncio
+async def test_edit_single_image_posts_multipart_with_input(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.openai.com/v1/images/edits",
+        json={"data": [{"b64_json": _FAKE_B64}]},
+    )
+
+    result = await edit_single_image(
+        api_key="test-key",
+        image_bytes=b"fake-input-image-bytes",
+        image_content_type="image/jpeg",
+        prompt="make it look nice",
+        provider_label="test_label",
+    )
+    assert result == _FAKE_PNG
+
+    req = httpx_mock.get_request(url="https://api.openai.com/v1/images/edits")
+    assert req is not None
+    assert req.headers["authorization"] == "Bearer test-key"
+    body = req.content.decode("utf-8", errors="replace")
+    # Multipart field names and values
+    assert 'name="image[]"' in body
+    assert 'name="prompt"' in body
+    assert "make it look nice" in body
+    assert "gpt-image-1.5" in body
+    # The actual input image bytes must be in the multipart body
+    assert "fake-input-image-bytes" in body
+
+
+@pytest.mark.asyncio
+async def test_edit_single_image_raises_on_missing_api_key():
+    with pytest.raises(OpenAIEditError):
+        await edit_single_image(
+            api_key="",
+            image_bytes=b"bytes",
+            image_content_type="image/png",
+            prompt="x",
+            provider_label="test",
+        )
+
+
+@pytest.mark.asyncio
+async def test_edit_single_image_raises_on_empty_bytes():
+    with pytest.raises(OpenAIEditError):
+        await edit_single_image(
+            api_key="test-key",
+            image_bytes=b"",
+            image_content_type="image/png",
+            prompt="x",
+            provider_label="test",
+        )
+
+
+@pytest.mark.asyncio
+async def test_edit_single_image_raises_on_api_error(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.openai.com/v1/images/edits",
+        status_code=429,
+        json={"error": {"message": "rate limit"}},
+    )
+    with pytest.raises(OpenAIEditError) as exc_info:
+        await edit_single_image(
+            api_key="test-key",
+            image_bytes=b"bytes",
+            image_content_type="image/png",
+            prompt="x",
+            provider_label="test",
+        )
+    assert "429" in str(exc_info.value)
+
+
+# ---------- helper: fetch_image_bytes ----------
+
+
+@pytest.mark.asyncio
+async def test_fetch_image_bytes_returns_content_and_type(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        method="GET",
+        url="https://s3.example.com/photo.jpg",
+        content=b"actual-jpeg-bytes",
+        headers={"content-type": "image/jpeg; charset=binary"},
+    )
+    data, ctype = await fetch_image_bytes("https://s3.example.com/photo.jpg")
+    assert data == b"actual-jpeg-bytes"
+    assert ctype == "image/jpeg"
+
+
+# ---------- OpenAIVirtualStagingProvider ----------
+
+
+@pytest.mark.asyncio
+async def test_staging_provider_actually_sends_input_image(httpx_mock: HTTPXMock):
+    """Regression test for the previous bug where stage_image called
+    /v1/images/generations (text-only) and never touched the source photo.
+    """
+    httpx_mock.add_response(
+        method="GET",
+        url="https://s3.example.com/empty_room.jpg",
+        content=b"real-empty-room-bytes",
+        headers={"content-type": "image/jpeg"},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.openai.com/v1/images/edits",
+        json={"data": [{"b64_json": _FAKE_B64}]},
+    )
+
+    provider = OpenAIVirtualStagingProvider(api_key="test-key")
+    result = await provider.stage_image(
+        image_url="https://s3.example.com/empty_room.jpg",
+        room_type="living_room",
+        style="modern",
+    )
+    assert result == _FAKE_PNG
+    assert isinstance(result, bytes)
+
+    # Confirm we hit the EDITS endpoint, not generations
+    edit_req = httpx_mock.get_request(url="https://api.openai.com/v1/images/edits")
+    assert edit_req is not None
+    body = edit_req.content.decode("utf-8", errors="replace")
+    assert "real-empty-room-bytes" in body  # input image was actually sent
+    assert "living room" in body
+    assert "modern" in body.lower() or "clean lines" in body.lower()
+
+
+@pytest.mark.asyncio
+async def test_staging_provider_raises_on_openai_error(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        method="GET",
+        url="https://s3.example.com/empty.jpg",
+        content=b"bytes",
+        headers={"content-type": "image/jpeg"},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.openai.com/v1/images/edits",
+        status_code=400,
+        json={"error": {"message": "content policy"}},
+    )
+    provider = OpenAIVirtualStagingProvider(api_key="test-key")
+    with pytest.raises(OpenAIEditError):
+        await provider.stage_image(
+            image_url="https://s3.example.com/empty.jpg",
+            room_type="bedroom",
+            style="modern",
+        )
+
+
+# ---------- OpenAIImageEditProvider ----------
+
+
+@pytest.mark.asyncio
+async def test_remove_object_actually_sends_input_image(httpx_mock: HTTPXMock):
+    """Regression test — remove_object used to hallucinate a fresh image
+    from text alone via the DALL-E 3 generations endpoint. Now it must
+    pass the real source bytes to /v1/images/edits.
+    """
+    httpx_mock.add_response(
+        method="GET",
+        url="https://s3.example.com/photo.jpg",
+        content=b"photo-with-yard-sign-bytes",
+        headers={"content-type": "image/jpeg"},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.openai.com/v1/images/edits",
+        json={"data": [{"b64_json": _FAKE_B64}]},
+    )
+
+    provider = OpenAIImageEditProvider(api_key="test-key")
+    result = await provider.remove_object(
+        image_url="https://s3.example.com/photo.jpg",
+        object_description="yard sign",
+    )
+    assert result == _FAKE_PNG
+    assert isinstance(result, bytes)
+
+    edit_req = httpx_mock.get_request(url="https://api.openai.com/v1/images/edits")
+    assert edit_req is not None
+    body = edit_req.content.decode("utf-8", errors="replace")
+    assert "photo-with-yard-sign-bytes" in body
+    assert "yard sign" in body
+
+
+@pytest.mark.asyncio
+async def test_enhance_actually_sends_input_image(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        method="GET",
+        url="https://s3.example.com/dark.jpg",
+        content=b"dim-photo-bytes",
+        headers={"content-type": "image/jpeg"},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.openai.com/v1/images/edits",
+        json={"data": [{"b64_json": _FAKE_B64}]},
+    )
+
+    provider = OpenAIImageEditProvider(api_key="test-key")
+    result = await provider.enhance(
+        image_url="https://s3.example.com/dark.jpg",
+        enhancement="brighten",
+    )
+    assert result == _FAKE_PNG
+
+    edit_req = httpx_mock.get_request(url="https://api.openai.com/v1/images/edits")
+    assert edit_req is not None
+    body = edit_req.content.decode("utf-8", errors="replace")
+    assert "dim-photo-bytes" in body
+    assert "golden-hour" in body or "brighten" in body.lower()
+
+
+@pytest.mark.asyncio
+async def test_enhance_falls_back_to_improve_quality_prompt(httpx_mock: HTTPXMock):
+    """Unknown enhancement name should use the 'improve_quality' prompt."""
+    httpx_mock.add_response(
+        method="GET",
+        url="https://s3.example.com/photo.jpg",
+        content=b"bytes",
+        headers={"content-type": "image/jpeg"},
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.openai.com/v1/images/edits",
+        json={"data": [{"b64_json": _FAKE_B64}]},
+    )
+    provider = OpenAIImageEditProvider(api_key="test-key")
+    await provider.enhance(
+        image_url="https://s3.example.com/photo.jpg",
+        enhancement="unknown_mode_xyz",
+    )
+    req = httpx_mock.get_request(url="https://api.openai.com/v1/images/edits")
+    body = req.content.decode("utf-8", errors="replace")
+    assert "magazine quality" in body.lower() or "sharpen" in body.lower()


### PR DESCRIPTION
## Summary

Both \`OpenAIVirtualStagingProvider.stage_image\` and \`OpenAIImageEditProvider.remove_object\` / \`enhance\` were calling DALL-E 3's \`/v1/images/generations\` endpoint, which is **text-only** — they never looked at the input photo. They hallucinated a generic staged room or a fresh object-free photo from the prompt alone, meaning:

- The \"staged\" bedroom had nothing to do with the customer's real bedroom.
- The \"yard sign removed\" photo was a completely different house.
- \`enhance\` (brighten / fix_lighting / improve_quality / declutter) generated a brand new fake photo every time instead of editing the real one.

### Fix

Port both providers to **gpt-image-1.5 via \`/v1/images/edits\`** with the source image attached as multipart form data. A new shared helper \`providers/_openai_edits.py\` exposes \`edit_single_image()\` and \`fetch_image_bytes()\` so both providers use identical wire semantics and metrics attribution.

Prompts now explicitly instruct the model to **preserve the room layout, walls, floors, ceiling, architecture, and existing furniture** and only modify the target (add furniture, remove yard sign, adjust lighting). Previous prompts didn't mention preservation because the model wasn't looking at the input anyway.

### Breaking change

\`VirtualStagingProvider.stage_image\` return type changed from \`-> str\` (URL) to \`-> bytes\` (raw PNG/JPEG). This removes a wasted HTTP round-trip in \`VirtualStagingAgent\` which was downloading the OpenAI-hosted URL just to re-upload the bytes to S3. The only consumer of \`stage_image\` is \`VirtualStagingAgent\`, which has been updated.

### Cost impact

- \`stage_image\` was already paying for DALL-E 3 HD (~\$0.08/call). Switching to gpt-image-1.5 medium/1536x1024 is **~\$0.05/call** — slightly cheaper.
- \`remove_object\` and \`enhance\` were paying for DALL-E 3 HD (~\$0.08/call). Now gpt-image-1.5 medium — **~\$0.05/call**.

### Files touched

- \`src/listingjet/providers/_openai_edits.py\` (new) — shared helper
- \`src/listingjet/providers/openai_image_edit.py\` — rewritten \`remove_object\` and \`enhance\`
- \`src/listingjet/providers/openai_staging.py\` — rewritten \`stage_image\`, returns bytes
- \`src/listingjet/providers/base.py\` — updated abstract method signature
- \`src/listingjet/providers/mock.py\` — \`MockVirtualStagingProvider\` returns bytes
- \`src/listingjet/agents/virtual_staging.py\` — drops the \`httpx\` download step
- \`tests/test_providers/test_openai_edits.py\` (new) — 10 tests

## Test plan

- [x] 10 new unit tests including regression tests asserting the input image bytes actually reach the API via multipart form
- [x] 186 existing tests still pass (full \`tests/test_providers\` + \`tests/test_agents\` + \`tests/test_api\` suite)
- [x] Ruff clean on all touched Python files
- [ ] **Review before merge**: Please eye a sample staged room output and a sample \`remove_object\` output before merging. The prompt wording is a first cut and will likely want tuning once you see what the model produces on real photos.
- [ ] Manual smoke: run the virtual_staging pipeline step against a listing with an empty room photo and confirm the staged output actually resembles the room (same walls/floors/windows).
- [ ] Manual smoke: hit \`POST /listings/{id}/assets/remove-object\` with a real photo and confirm the result is the same photo minus the target, not a hallucinated fresh image.

## Notes

- This PR is independent of #201 (dollhouse render). Can merge in either order.
- The \`v3\` in the branch name is an artifact of local branch-juggling while recovering from a confused working tree — not meaningful, feel free to ignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)