### PR TITLE
fix(ux): listing page title uses real address + support page shows errors

### DIFF
--- a/frontend/src/app/listings/[id]/page.tsx
+++ b/frontend/src/app/listings/[id]/page.tsx
@@ -72,7 +72,10 @@ function ListingDetail() {
     }
   }, [id]);
 
-  useEffect(() => { document.title = "Listing Detail | ListingJet"; }, []);
+  useEffect(() => {
+    const street = listing?.address?.street;
+    document.title = street ? `${street} | ListingJet` : "Listing Detail | ListingJet";
+  }, [listing]);
 
   useEffect(() => {
     fetchData();

--- a/frontend/src/app/support/page.tsx
+++ b/frontend/src/app/support/page.tsx
@@ -54,6 +54,7 @@ function SupportPage() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [detail, setDetail] = useState<SupportTicketDetail | null>(null);
   const [loading, setLoading] = useState(true);
+  const [ticketsError, setTicketsError] = useState<string | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
   const [showCreate, setShowCreate] = useState(false);
   const [statusFilter, setStatusFilter] = useState<string>("all");
@@ -68,11 +69,12 @@ function SupportPage() {
   const [creating, setCreating] = useState(false);
 
   const fetchTickets = useCallback(async () => {
+    setTicketsError(null);
     try {
       const res = await apiClient.getSupportTickets(statusFilter === "all" ? undefined : statusFilter);
       setTickets(res.items);
-    } catch {
-      // silently handle
+    } catch (err) {
+      setTicketsError(err instanceof Error ? err.message : "Failed to load tickets");
     } finally {
       setLoading(false);
     }
@@ -210,6 +212,18 @@ function SupportPage() {
           <div className="space-y-2">
             {loading ? (
               [1, 2, 3].map((i) => <div key={i} className="h-16 rounded-xl bg-[var(--color-surface)] animate-pulse border border-[var(--color-card-border)]" />)
+            ) : ticketsError ? (
+              <div className="rounded-xl border border-red-200 bg-red-50 dark:bg-red-900/10 dark:border-red-900/40 p-4 text-center">
+                <p className="text-sm text-red-700 dark:text-red-300 mb-3">
+                  Couldn&apos;t load tickets. {ticketsError}
+                </p>
+                <button
+                  onClick={() => { setLoading(true); fetchTickets(); }}
+                  className="px-4 py-1.5 rounded-full bg-[#F97316] hover:bg-[#ea580c] text-white text-xs font-semibold transition-colors"
+                >
+                  Retry
+                </button>
+              </div>
             ) : tickets.length === 0 ? (
               <p className="text-sm text-[var(--color-text-secondary)] text-center py-8">No tickets yet. Try the AI chat first!</p>
             ) : (


### PR DESCRIPTION
## Summary

Two safe quick wins from the UX audit that don't need design discussion.

### C002 — Listing detail page title

\`listings/[id]/page.tsx:75\` hardcoded \`document.title = \"Listing Detail | ListingJet\"\` in a useEffect with empty deps. A user with 10 listing tabs open in their browser could not tell them apart. Now the useEffect depends on \`[listing]\` and renders the actual street address as soon as the listing data loads, falling back to the generic title only in the initial loading state.

### W005 — Support page silently swallows fetch errors

\`support/page.tsx:75\` had \`catch { // silently handle }\`, so if the tickets list failed to load the user saw a blank panel — especially ironic on the support page itself. Now sets a \`ticketsError\` state in the catch block and renders a dedicated error card with the message and a Retry button when the list can't load.

## What else from the UX audit

I investigated the two remaining critical items (C003 and C004) and surface the findings here so you can scope the follow-up:

**C003 — \`window.confirm\` for team removal + password in invite form.** Confirmed still present in \`settings/team/page.tsx\`. Removal at line 142, invite password field at line 267. The backend schema \`InviteTeamMemberRequest\` also hardcodes \`password: str\` as required (\`api/schemas/team.py:21\`) — so fixing this properly means: (1) remove the password field from the frontend form, (2) change \`POST /team/members\` to generate a signed invite token instead, (3) add a \`POST /auth/accept-invite/{token}\` endpoint where the invitee sets their own password, (4) add an email template for the invite link, (5) replace \`window.confirm\` with a modal dialog. Substantial work — multiple files, DB migration for an invite-token column, email template. Not a quick fix.

**C004 — Error boundary fallback content.** Audit said the fallback had no content or recovery path. That's inaccurate — \`error-boundary.tsx\` already has a red icon, heading (\"Something went wrong\"), the actual error message from \`state.error\`, and a \"Try Again\" button that resets state. The one missing piece is a \"Go to Dashboard\" link for when Try Again doesn't fix the problem. Tiny fix (one \`<Link>\` component), can be included in a future UX batch.

I did not include C003 or C004 in this PR because C003 is large and C004 is debatable.

## Test plan

- [x] Frontend \`tsc --noEmit\` clean
- [ ] Manual: open two listings in separate tabs, verify each tab title shows the correct address
- [ ] Manual: toggle API off (stop backend) and load /support — verify the error card renders with a working Retry button instead of a blank panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)