### PR TITLE
feat(team): proper invite-token flow (C003 backend)

### DIFF
--- a/alembic/versions/049_team_invite_tokens.py
+++ b/alembic/versions/049_team_invite_tokens.py
@@ -1,0 +1,53 @@
+"""Add invite-token flow for team member invitations.
+
+Revision ID: 049_team_invite_tokens
+Revises: 048_ai_consent
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "049_team_invite_tokens"
+down_revision = "048_ai_consent"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Invited users exist in the users table without a password until they
+    # accept. password_hash must allow NULL for that window.
+    op.alter_column("users", "password_hash", existing_type=sa.String(255), nullable=True)
+
+    # SHA-256 hex of the invite token we email the user. The raw token is
+    # never stored — only its hash, so a DB read does not leak the token.
+    op.add_column(
+        "users",
+        sa.Column("invite_token_hash", sa.String(64), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("invite_expires_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("invited_by_user_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=True),
+    )
+
+    op.create_index(
+        "ix_users_invite_token_hash",
+        "users",
+        ["invite_token_hash"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_invite_token_hash", table_name="users")
+    op.drop_column("users", "invited_by_user_id")
+    op.drop_column("users", "invite_expires_at")
+    op.drop_column("users", "invite_token_hash")
+    # Any users with NULL password_hash must be deleted or have a password
+    # set before the downgrade can run without constraint violation.
+    op.execute("DELETE FROM users WHERE password_hash IS NULL")
+    op.alter_column("users", "password_hash", existing_type=sa.String(255), nullable=False)

--- a/src/listingjet/api/auth.py
+++ b/src/listingjet/api/auth.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -9,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from listingjet.api.deps import get_current_user
 from listingjet.api.schemas.auth import LoginRequest, RegisterRequest, TokenResponse, UserResponse
+from listingjet.api.schemas.team import AcceptInviteRequest, InviteInfoResponse
 from listingjet.config.tiers import TIER_DEFAULTS
 from listingjet.config.tiers import TIER_TO_PLAN as _TIER_TO_PLAN
 from listingjet.database import get_db
@@ -20,6 +22,7 @@ from listingjet.services.auth import (
     create_access_token,
     create_refresh_token,
     decode_token,
+    hash_invite_token,
     hash_password,
     set_auth_cookies,
     verify_password_constant_time,
@@ -564,3 +567,95 @@ async def google_login(
     refresh = create_refresh_token(user)
     body = TokenResponse(access_token=access, refresh_token=refresh)
     return set_auth_cookies(JSONResponse(content=body.model_dump()), access, refresh)
+
+
+# ---------------------------------------------------------------------------
+# Team invite acceptance
+# ---------------------------------------------------------------------------
+
+
+async def _lookup_pending_invite(db: AsyncSession, raw_token: str) -> User:
+    """Resolve a raw invite token to its pending User row, or raise 404/410."""
+    if not raw_token:
+        raise HTTPException(status_code=404, detail="Invitation not found")
+    token_hash = hash_invite_token(raw_token)
+    user = (
+        await db.execute(
+            select(User).where(User.invite_token_hash == token_hash)
+        )
+    ).scalar_one_or_none()
+    if not user:
+        raise HTTPException(status_code=404, detail="Invitation not found")
+    if user.invite_expires_at is None or user.invite_expires_at < datetime.now(timezone.utc):
+        raise HTTPException(status_code=410, detail="Invitation expired")
+    return user
+
+
+@router.get("/invite/{token}", response_model=InviteInfoResponse)
+async def get_invite_info(
+    token: str,
+    db: AsyncSession = Depends(get_db),
+    _rl=Depends(rate_limit(30, 60)),
+):
+    """Public lookup of a pending invitation. Used by the accept page to
+    display the invitee's email and the tenant they're joining before they
+    set a password.
+    """
+    user = await _lookup_pending_invite(db, token)
+    tenant = await db.get(Tenant, user.tenant_id)
+    inviter = (
+        await db.get(User, user.invited_by_user_id)
+        if user.invited_by_user_id
+        else None
+    )
+    return InviteInfoResponse(
+        email=user.email,
+        tenant_name=tenant.name if tenant else "this team",
+        inviter_name=(inviter.name or inviter.email) if inviter else None,
+        expires_at=user.invite_expires_at,
+    )
+
+
+@router.post("/accept-invite", response_model=TokenResponse)
+async def accept_invite(
+    body: AcceptInviteRequest,
+    db: AsyncSession = Depends(get_db),
+    _rl=Depends(rate_limit(10, 60)),
+):
+    """Accept a team invitation: set the invitee's password and log them in.
+
+    The invite token is consumed on success — invite_token_hash and
+    invite_expires_at are cleared, preventing replay.
+    """
+    user = await _lookup_pending_invite(db, body.token)
+
+    if user.password_hash is not None:
+        # The row already has a password — the invite was already accepted
+        # (shouldn't happen because we clear the token on accept, but guard
+        # anyway in case of concurrent requests).
+        raise HTTPException(status_code=409, detail="Invitation already accepted")
+
+    user.password_hash = hash_password(body.password)
+    if body.name:
+        user.name = body.name
+    user.invite_token_hash = None
+    user.invite_expires_at = None
+    # consent_at: the invitee is accepting the terms of service by creating
+    # their account just like a self-registration.
+    user.consent_at = datetime.now(timezone.utc)
+    user.consent_version = "2026-04-03"
+
+    await emit_event(
+        session=db,
+        event_type="user.invite_accepted",
+        payload={"user_id": str(user.id), "email": user.email},
+        tenant_id=str(user.tenant_id),
+    )
+    await db.commit()
+    await db.refresh(user)
+
+    logger.info("auth.invite_accepted user=%s tenant=%s", user.id, user.tenant_id)
+    access = create_access_token(user)
+    refresh = create_refresh_token(user)
+    token_body = TokenResponse(access_token=access, refresh_token=refresh)
+    return set_auth_cookies(JSONResponse(content=token_body.model_dump()), access, refresh)

--- a/src/listingjet/api/schemas/team.py
+++ b/src/listingjet/api/schemas/team.py
@@ -3,7 +3,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class TeamMemberResponse(BaseModel):
@@ -12,14 +12,39 @@ class TeamMemberResponse(BaseModel):
     email: str
     role: str
     created_at: datetime
+    # Populated when the user has a pending invitation and has not yet set
+    # a password. Frontend can show a "Pending" indicator.
+    pending_invite: bool = False
     model_config = {"from_attributes": True}
 
 
 class InviteTeamMemberRequest(BaseModel):
     email: str
     name: str | None = None
-    password: str
     role: str = "agent"
+
+
+class InviteTeamMemberResponse(BaseModel):
+    """Returned from POST /team/members after sending the invitation email."""
+    id: uuid.UUID
+    email: str
+    name: str | None
+    role: str
+    invite_expires_at: datetime
+
+
+class InviteInfoResponse(BaseModel):
+    """Public lookup of an invitation from its token — used by the accept page."""
+    email: str
+    tenant_name: str
+    inviter_name: str | None
+    expires_at: datetime
+
+
+class AcceptInviteRequest(BaseModel):
+    token: str
+    password: str = Field(min_length=8)
+    name: str | None = None
 
 
 class UpdateRoleRequest(BaseModel):

--- a/src/listingjet/api/team.py
+++ b/src/listingjet/api/team.py
@@ -3,14 +3,16 @@ Team API — manage team members within a tenant.
 
 Endpoints:
   GET    /team/members              — list users in current tenant (admin+)
-  POST   /team/members              — invite new member (admin+)
+  POST   /team/members              — invite new member (admin+); sends
+                                       an invite email with an accept link
   PATCH  /team/members/{member_id}/role — change role (admin+)
   DELETE /team/members/{member_id}  — remove member (admin+)
   GET    /team/me                   — current user profile + role
 """
 
+import logging
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
@@ -23,13 +25,21 @@ from listingjet.api.schemas.listing_permission import (
 )
 from listingjet.api.schemas.team import (
     InviteTeamMemberRequest,
+    InviteTeamMemberResponse,
     TeamMemberResponse,
     UpdateRoleRequest,
 )
+from listingjet.config import settings
 from listingjet.database import get_db
 from listingjet.models.listing_permission import ListingPermission
+from listingjet.models.tenant import Tenant
 from listingjet.models.user import User, UserRole
-from listingjet.services.auth import hash_password
+from listingjet.services.auth import generate_invite_token
+from listingjet.services.email import get_email_service
+
+logger = logging.getLogger(__name__)
+
+INVITE_EXPIRY_HOURS = 72
 
 router = APIRouter()
 
@@ -60,16 +70,38 @@ async def list_members(
         .where(User.tenant_id == current_user.tenant_id)
         .order_by(User.created_at)
     )
-    return result.scalars().all()
+    members = result.scalars().all()
+    return [_to_team_member_response(u) for u in members]
 
 
-@router.post("/members", response_model=TeamMemberResponse, status_code=201)
+def _to_team_member_response(user: User) -> TeamMemberResponse:
+    return TeamMemberResponse(
+        id=user.id,
+        name=user.name,
+        email=user.email,
+        role=user.role.value,
+        created_at=user.created_at,
+        pending_invite=user.password_hash is None,
+    )
+
+
+def _build_invite_accept_url(raw_token: str) -> str:
+    base = (settings.frontend_url or "https://app.listingjet.com").rstrip("/")
+    return f"{base}/accept-invite?token={raw_token}"
+
+
+@router.post("/members", response_model=InviteTeamMemberResponse, status_code=201)
 async def invite_member(
     body: InviteTeamMemberRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Invite (create) a new team member in the current tenant. Requires admin+."""
+    """Invite a new team member. Creates a pending user row, generates a
+    signed invite token, and emails the invitee an accept link.
+
+    The admin does NOT set the invitee's password — the invitee sets it
+    themselves via POST /auth/accept-invite.
+    """
     _require_admin(current_user)
 
     # Validate requested role
@@ -91,18 +123,50 @@ async def invite_member(
     if existing:
         raise HTTPException(status_code=409, detail="Email already registered")
 
+    # Generate invite token. Raw goes in the email, hash goes in the DB.
+    raw_token, token_hash = generate_invite_token()
+    expires_at = datetime.now(timezone.utc) + timedelta(hours=INVITE_EXPIRY_HOURS)
+
     user = User(
         id=uuid.uuid4(),
         tenant_id=current_user.tenant_id,
         email=email,
-        password_hash=hash_password(body.password),
+        password_hash=None,  # will be set when the invitee accepts
         name=body.name,
         role=requested_role,
+        invite_token_hash=token_hash,
+        invite_expires_at=expires_at,
+        invited_by_user_id=current_user.id,
     )
     db.add(user)
     await db.commit()
     await db.refresh(user)
-    return user
+
+    # Send the invite email. Fire-and-forget — failure to send should not
+    # block the invitation record.
+    try:
+        tenant = await db.get(Tenant, current_user.tenant_id)
+        email_svc = get_email_service()
+        email_svc.send_notification(
+            user.email,
+            "team_member_invite",
+            inviter_name=current_user.name or current_user.email,
+            tenant_name=tenant.name if tenant else "your team",
+            accept_url=_build_invite_accept_url(raw_token),
+            expires_hours=INVITE_EXPIRY_HOURS,
+        )
+    except Exception as exc:
+        logger.warning(
+            "team_invite.email_failed user=%s error=%s", user.id, exc
+        )
+
+    return InviteTeamMemberResponse(
+        id=user.id,
+        email=user.email,
+        name=user.name,
+        role=user.role.value,
+        invite_expires_at=expires_at,
+    )
 
 
 @router.patch("/members/{member_id}/role", response_model=TeamMemberResponse)

--- a/src/listingjet/config/__init__.py
+++ b/src/listingjet/config/__init__.py
@@ -73,6 +73,10 @@ class Settings(BaseSettings):
     # Redis
     redis_url: str = "redis://localhost:6379/0"
 
+    # Frontend base URL — used for constructing links in transactional emails
+    # (invite accept, password reset, etc).
+    frontend_url: str = "https://app.listingjet.com"
+
     # S3
     s3_bucket_name: str = "listingjet-dev"
     aws_region: str = "us-east-1"

--- a/src/listingjet/middleware/tenant.py
+++ b/src/listingjet/middleware/tenant.py
@@ -5,7 +5,11 @@ from starlette.responses import JSONResponse
 
 from listingjet.config import settings
 
-_PUBLIC_PATHS = {"/health", "/health/deep", "/auth/register", "/auth/login", "/auth/refresh", "/auth/forgot-password", "/auth/reset-password", "/billing/webhook", "/demo/upload", "/addons", "/branding"}
+_PUBLIC_PATHS = {"/health", "/health/deep", "/auth/register", "/auth/login", "/auth/refresh", "/auth/forgot-password", "/auth/reset-password", "/auth/accept-invite", "/billing/webhook", "/demo/upload", "/addons", "/branding"}
+
+# Prefix matches for routes with a path parameter that must be public
+# (e.g. GET /auth/invite/{token}, the public invite lookup).
+_PUBLIC_PREFIXES = ("/auth/invite/",)
 
 
 class TenantMiddleware:
@@ -15,7 +19,11 @@ class TenantMiddleware:
             return await call_next(request)
 
         path = request.url.path
-        if path in _PUBLIC_PATHS or (path.startswith("/demo/") and request.method == "GET"):
+        if (
+            path in _PUBLIC_PATHS
+            or any(path.startswith(p) for p in _PUBLIC_PREFIXES)
+            or (path.startswith("/demo/") and request.method == "GET")
+        ):
             return await call_next(request)
 
         auth = request.headers.get("Authorization", "")

--- a/src/listingjet/models/user.py
+++ b/src/listingjet/models/user.py
@@ -22,11 +22,16 @@ class User(Base):
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
-    password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    # Nullable while an invitation is pending — set on accept.
+    password_hash: Mapped[str | None] = mapped_column(String(255), nullable=True)
     name: Mapped[str | None] = mapped_column(String(255))
     role: Mapped[UserRole] = mapped_column(SAEnum(UserRole, values_callable=lambda x: [e.value for e in x]), default=UserRole.OPERATOR)
     consent_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     consent_version: Mapped[str | None] = mapped_column(String(20), nullable=True)
     ai_consent_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     ai_consent_version: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    # Team invitation fields. Populated on invite, cleared on accept.
+    invite_token_hash: Mapped[str | None] = mapped_column(String(64), nullable=True, unique=True, index=True)
+    invite_expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    invited_by_user_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/src/listingjet/services/auth.py
+++ b/src/listingjet/services/auth.py
@@ -1,4 +1,6 @@
+import hashlib
 import logging
+import secrets
 from datetime import datetime, timedelta, timezone
 
 import bcrypt
@@ -33,6 +35,21 @@ def verify_password_constant_time(plain: str, hashed: str | None) -> bool:
     """Verify password with constant-time behaviour even when user doesn't exist."""
     target = hashed if hashed is not None else _DUMMY_HASH
     return bcrypt.checkpw(plain.encode(), target.encode())
+
+
+# --- Invitation tokens ---------------------------------------------------
+# Raw tokens are emailed to invitees; only their SHA-256 hash is stored in
+# the DB so a read-only database leak cannot be used to accept invitations.
+
+
+def generate_invite_token() -> tuple[str, str]:
+    """Return (raw_token, hash). Raw goes in the email link, hash goes to DB."""
+    raw = secrets.token_urlsafe(32)
+    return raw, hash_invite_token(raw)
+
+
+def hash_invite_token(raw: str) -> str:
+    return hashlib.sha256(raw.encode()).hexdigest()
 
 
 def create_access_token(user: User) -> str:

--- a/src/listingjet/services/email_templates.py
+++ b/src/listingjet/services/email_templates.py
@@ -237,6 +237,35 @@ def _social_reminder_followup(**kwargs) -> tuple[str, str]:
     return subject, html_body
 
 
+def team_member_invite(
+    *,
+    inviter_name: str,
+    tenant_name: str,
+    accept_url: str,
+    expires_hours: int = 72,
+) -> tuple[str, str]:
+    """TEAM_MEMBER_INVITE — invitation to join a tenant's team."""
+    subject = f"{inviter_name} invited you to {tenant_name} on ListingJet"
+    content = (
+        f"<h2 style=\"color:#0F1B2D;margin:0 0 16px;\">You've been invited</h2>"
+        f"<p style=\"font-size:16px;color:#334155;\">"
+        f"<strong>{inviter_name}</strong> invited you to join "
+        f"<strong>{tenant_name}</strong> on ListingJet. "
+        f"Click the button below to set your password and get started."
+        f"</p>"
+        f"<p style=\"margin:32px 0;\">{_CTA_BUTTON.format(url=accept_url, label='Accept Invitation')}</p>"
+        f"<p style=\"font-size:14px;color:#64748B;\">"
+        f"This invitation expires in {expires_hours} hours. "
+        f"If the button doesn't work, copy and paste this link into your browser:"
+        f"</p>"
+        f"<p style=\"font-size:13px;color:#64748B;word-break:break-all;\">{accept_url}</p>"
+        f"<p style=\"font-size:13px;color:#94A3B8;margin-top:24px;\">"
+        f"If you weren't expecting this invitation, you can safely ignore this email."
+        f"</p>"
+    )
+    return subject, _render(content)
+
+
 # Registry mapping template names to functions
 TEMPLATES: dict[str, callable] = {
     "listing_delivered": listing_delivered,
@@ -251,4 +280,5 @@ TEMPLATES: dict[str, callable] = {
     "welcome_drip_5": welcome_drip_5,
     "social_reminder": _social_reminder,
     "social_reminder_followup": _social_reminder_followup,
+    "team_member_invite": team_member_invite,
 }

--- a/tests/test_api/test_team_invites.py
+++ b/tests/test_api/test_team_invites.py
@@ -1,0 +1,428 @@
+"""Tests for the team invite-token flow.
+
+Covers:
+  POST /team/members           — admin invites a new member; pending user row
+                                 created with null password; email sent
+  GET  /auth/invite/{token}    — public invite lookup (email, tenant name)
+  POST /auth/accept-invite     — invitee sets password, consumes token, logs in
+  GET  /team/members           — pending_invite flag on listed users
+  POST /auth/login             — rejected for users with null password_hash
+"""
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import jwt as pyjwt
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from listingjet.config import settings
+from listingjet.models.user import User
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _register_admin(client: AsyncClient) -> tuple[str, str, str]:
+    """Register a tenant admin user. Returns (token, tenant_id, email)."""
+    email = f"owner-{uuid.uuid4()}@example.com"
+    resp = await client.post(
+        "/auth/register",
+        json={
+            "email": email,
+            "password": "OwnerPass1!",
+            "name": "Owner",
+            "company_name": "OwnerCo",
+            "plan_tier": "free",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    token = resp.json()["access_token"]
+    payload = pyjwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
+    return token, payload["tenant_id"], email
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(autouse=True)
+def mock_email_service():
+    """Replace the email service with a no-op so tests don't hit SMTP/SES."""
+    svc = MagicMock()
+    svc.send_notification = MagicMock()
+    svc.send = MagicMock()
+    with patch("listingjet.api.team.get_email_service", return_value=svc):
+        yield svc
+
+
+# ---------------------------------------------------------------------------
+# POST /team/members — sending an invitation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invite_creates_pending_user_with_no_password(
+    async_client: AsyncClient, mock_email_service, db_session
+):
+    token, tenant_id, _ = await _register_admin(async_client)
+
+    resp = await async_client.post(
+        "/team/members",
+        json={"email": "new@example.com", "name": "New Person", "role": "agent"},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["email"] == "new@example.com"
+    assert body["name"] == "New Person"
+    assert body["role"] == "agent"
+    assert "invite_expires_at" in body
+
+    # Pending row in DB: no password, has token hash, expires in the future
+    invited = (
+        await db_session.execute(
+            select(User).where(User.email == "new@example.com")
+        )
+    ).scalar_one()
+    assert invited.password_hash is None
+    assert invited.invite_token_hash is not None
+    assert invited.invite_expires_at is not None
+    assert invited.invite_expires_at > datetime.now(timezone.utc)
+    assert str(invited.tenant_id) == tenant_id
+    assert invited.role.value == "agent"
+
+
+@pytest.mark.asyncio
+async def test_invite_sends_email(async_client: AsyncClient, mock_email_service):
+    token, _tenant_id, _ = await _register_admin(async_client)
+
+    resp = await async_client.post(
+        "/team/members",
+        json={"email": "mail-test@example.com", "role": "agent"},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 201
+
+    mock_email_service.send_notification.assert_called_once()
+    args, kwargs = mock_email_service.send_notification.call_args
+    # First positional arg is the recipient email
+    assert args[0] == "mail-test@example.com"
+    assert args[1] == "team_member_invite"
+    assert "accept_url" in kwargs
+    assert "/accept-invite?token=" in kwargs["accept_url"]
+    assert kwargs["tenant_name"] == "OwnerCo"
+
+
+@pytest.mark.asyncio
+async def test_invite_duplicate_email_rejected(
+    async_client: AsyncClient, mock_email_service
+):
+    token, _tenant_id, owner_email = await _register_admin(async_client)
+
+    # Inviting with the owner's own email should conflict
+    resp = await async_client.post(
+        "/team/members",
+        json={"email": owner_email, "role": "agent"},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_invite_invalid_role_rejected(
+    async_client: AsyncClient, mock_email_service
+):
+    token, _tenant_id, _ = await _register_admin(async_client)
+
+    resp = await async_client.post(
+        "/team/members",
+        json={"email": "bad-role@example.com", "role": "potato"},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_invite_cannot_escalate_to_superadmin(
+    async_client: AsyncClient, mock_email_service
+):
+    token, _tenant_id, _ = await _register_admin(async_client)
+
+    resp = await async_client.post(
+        "/team/members",
+        json={"email": "escalation@example.com", "role": "superadmin"},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_invite_ignores_password_in_body(
+    async_client: AsyncClient, mock_email_service, db_session
+):
+    """Even if an old client POSTs password, it must not be set on the user."""
+    token, _tenant_id, _ = await _register_admin(async_client)
+
+    resp = await async_client.post(
+        "/team/members",
+        json={
+            "email": "legacy@example.com",
+            "role": "agent",
+            "password": "HaxxorAttempt1!",  # Extra field — schema ignores it
+        },
+        headers=_auth(token),
+    )
+    assert resp.status_code == 201
+
+    invited = (
+        await db_session.execute(
+            select(User).where(User.email == "legacy@example.com")
+        )
+    ).scalar_one()
+    assert invited.password_hash is None
+
+
+# ---------------------------------------------------------------------------
+# GET /auth/invite/{token} — public invite lookup
+# ---------------------------------------------------------------------------
+
+
+async def _invite_and_capture_token(
+    async_client: AsyncClient, mock_email_service, email: str | None = None
+) -> tuple[str, str]:
+    """Helper: invite a user and return (raw_token, invitee_email).
+
+    Uses a unique email per call so tests don't collide on DB state.
+    """
+    if email is None:
+        email = f"invitee-{uuid.uuid4()}@example.com"
+    owner_token, _tenant_id, _ = await _register_admin(async_client)
+    resp = await async_client.post(
+        "/team/members",
+        json={"email": email, "name": "Invitee", "role": "agent"},
+        headers=_auth(owner_token),
+    )
+    assert resp.status_code == 201, resp.text
+
+    # The raw token is the `?token=...` parameter passed to accept_url
+    kwargs = mock_email_service.send_notification.call_args.kwargs
+    accept_url = kwargs["accept_url"]
+    return accept_url.split("token=", 1)[1], email
+
+
+@pytest.mark.asyncio
+async def test_get_invite_info_returns_details(
+    async_client: AsyncClient, mock_email_service
+):
+    raw_token, invitee_email = await _invite_and_capture_token(async_client, mock_email_service)
+
+    resp = await async_client.get(f"/auth/invite/{raw_token}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["email"] == invitee_email
+    assert body["tenant_name"] == "OwnerCo"
+    assert body["inviter_name"] == "Owner"
+
+
+@pytest.mark.asyncio
+async def test_get_invite_info_returns_404_for_invalid_token(
+    async_client: AsyncClient,
+):
+    resp = await async_client.get("/auth/invite/not-a-real-token")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_invite_info_returns_410_for_expired_token(
+    async_client: AsyncClient, mock_email_service, db_session
+):
+    raw_token, invitee_email = await _invite_and_capture_token(async_client, mock_email_service)
+
+    # Backdate the expiry
+    invited = (
+        await db_session.execute(
+            select(User).where(User.email == invitee_email)
+        )
+    ).scalar_one()
+    invited.invite_expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    await db_session.commit()
+
+    resp = await async_client.get(f"/auth/invite/{raw_token}")
+    assert resp.status_code == 410
+
+
+# ---------------------------------------------------------------------------
+# POST /auth/accept-invite — setting password and logging in
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_accept_invite_sets_password_and_clears_token(
+    async_client: AsyncClient, mock_email_service, db_session
+):
+    raw_token, invitee_email = await _invite_and_capture_token(async_client, mock_email_service)
+
+    resp = await async_client.post(
+        "/auth/accept-invite",
+        json={"token": raw_token, "password": "NewUserPass1!"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "access_token" in body
+    assert "refresh_token" in body
+
+    # DB state: password set, token cleared
+    accepted = (
+        await db_session.execute(
+            select(User).where(User.email == invitee_email)
+        )
+    ).scalar_one()
+    assert accepted.password_hash is not None
+    assert accepted.invite_token_hash is None
+    assert accepted.invite_expires_at is None
+    assert accepted.consent_at is not None
+
+
+@pytest.mark.asyncio
+async def test_accept_invite_can_override_name(
+    async_client: AsyncClient, mock_email_service, db_session
+):
+    raw_token, invitee_email = await _invite_and_capture_token(async_client, mock_email_service)
+
+    resp = await async_client.post(
+        "/auth/accept-invite",
+        json={
+            "token": raw_token,
+            "password": "NewUserPass1!",
+            "name": "Real Name",
+        },
+    )
+    assert resp.status_code == 200
+
+    accepted = (
+        await db_session.execute(
+            select(User).where(User.email == invitee_email)
+        )
+    ).scalar_one()
+    assert accepted.name == "Real Name"
+
+
+@pytest.mark.asyncio
+async def test_accept_invite_rejected_on_second_use(
+    async_client: AsyncClient, mock_email_service
+):
+    raw_token, _invitee_email = await _invite_and_capture_token(async_client, mock_email_service)
+
+    first = await async_client.post(
+        "/auth/accept-invite",
+        json={"token": raw_token, "password": "FirstPass1!"},
+    )
+    assert first.status_code == 200
+
+    # Second attempt with the same token should 404 (token was cleared)
+    second = await async_client.post(
+        "/auth/accept-invite",
+        json={"token": raw_token, "password": "SecondPass1!"},
+    )
+    assert second.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_accept_invite_rejected_when_expired(
+    async_client: AsyncClient, mock_email_service, db_session
+):
+    raw_token, invitee_email = await _invite_and_capture_token(async_client, mock_email_service)
+    invited = (
+        await db_session.execute(
+            select(User).where(User.email == invitee_email)
+        )
+    ).scalar_one()
+    invited.invite_expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    await db_session.commit()
+
+    resp = await async_client.post(
+        "/auth/accept-invite",
+        json={"token": raw_token, "password": "LatePass1!"},
+    )
+    assert resp.status_code == 410
+
+
+@pytest.mark.asyncio
+async def test_accept_invite_requires_minimum_password_length(
+    async_client: AsyncClient, mock_email_service
+):
+    raw_token, _invitee_email = await _invite_and_capture_token(async_client, mock_email_service)
+
+    resp = await async_client.post(
+        "/auth/accept-invite",
+        json={"token": raw_token, "password": "short"},
+    )
+    assert resp.status_code == 422  # Pydantic validation failure
+
+
+# ---------------------------------------------------------------------------
+# Login + listing behaviour with pending invites
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_login_fails_for_pending_invitee(
+    async_client: AsyncClient, mock_email_service
+):
+    _raw_token, invitee_email = await _invite_and_capture_token(async_client, mock_email_service)
+
+    resp = await async_client.post(
+        "/auth/login",
+        json={"email": invitee_email, "password": "AnyPassword1!"},
+    )
+    assert resp.status_code == 401  # Generic invalid credentials
+
+
+@pytest.mark.asyncio
+async def test_login_succeeds_after_accept(
+    async_client: AsyncClient, mock_email_service
+):
+    raw_token, invitee_email = await _invite_and_capture_token(async_client, mock_email_service)
+
+    # Accept the invite
+    accept = await async_client.post(
+        "/auth/accept-invite",
+        json={"token": raw_token, "password": "NewUserPass1!"},
+    )
+    assert accept.status_code == 200
+
+    # Now log in with the new password
+    login = await async_client.post(
+        "/auth/login",
+        json={"email": invitee_email, "password": "NewUserPass1!"},
+    )
+    assert login.status_code == 200
+    assert "access_token" in login.json()
+
+
+@pytest.mark.asyncio
+async def test_team_list_shows_pending_flag(
+    async_client: AsyncClient, mock_email_service
+):
+    owner_token, _tenant_id, _ = await _register_admin(async_client)
+
+    # Invite someone
+    await async_client.post(
+        "/team/members",
+        json={"email": "pending-list@example.com", "role": "agent"},
+        headers=_auth(owner_token),
+    )
+
+    resp = await async_client.get("/team/members", headers=_auth(owner_token))
+    assert resp.status_code == 200
+    members = resp.json()
+    by_email = {m["email"]: m for m in members}
+
+    # Invitee shows as pending
+    assert by_email["pending-list@example.com"]["pending_invite"] is True
+    # Owner (who registered normally) is not pending
+    owner_row = next(m for m in members if m["email"].startswith("owner-"))
+    assert owner_row["pending_invite"] is False


### PR DESCRIPTION
## Summary

Fixes the biggest item from the UX audit (C003): the team invite flow used to ask the admin to type a temporary password for the invitee. Entering another person's password on their behalf is a trust/security UX anti-pattern and it meant the admin knew the invitee's initial credentials.

This PR replaces that with a proper invite-token flow:

1. Admin POSTs email + name + role (no password)
2. Backend creates a pending user row with \`password_hash=null\`, generates a signed invite token (raw emailed, SHA-256 hash stored), sends an invitation email with an accept link
3. Invitee clicks the link, hits \`GET /auth/invite/{token}\` to see who invited them, then \`POST /auth/accept-invite\` with their chosen password
4. Backend sets the password, clears the token, emits an event, and returns access tokens so the invitee is immediately logged in

This is **Batch 1 (backend-only)**. Batch 2 removes the password field from the frontend invite form, adds the \`/accept-invite\` page, and replaces \`window.confirm\` with a modal dialog. The two batches are independently mergeable.

## What changed

- **Migration 049_team_invite_tokens**: makes \`users.password_hash\` nullable, adds \`invite_token_hash\` (unique-indexed), \`invite_expires_at\`, \`invited_by_user_id\`.
- **User model**: \`password_hash: Mapped[str | None]\`, new invite columns.
- **services/auth.py**: new \`generate_invite_token()\` returns \`(raw, sha256 hash)\`. Raw is emailed, hash is stored — a read-only DB leak cannot be used to accept invitations.
- **schemas/team.py**: \`InviteTeamMemberRequest\` drops the \`password\` field; new \`InviteTeamMemberResponse\` / \`InviteInfoResponse\` / \`AcceptInviteRequest\`; \`TeamMemberResponse\` gains a \`pending_invite\` boolean so the frontend can show a badge.
- **email_templates.py**: new \`team_member_invite\` template.
- **api/team.py**: \`POST /team/members\` rewritten. Email failure is logged but doesn't fail the invite (same pattern as the welcome drip). \`GET /team/members\` returns \`pending_invite=True\` for rows without a password.
- **api/auth.py**: new \`GET /auth/invite/{token}\` (public lookup — email, tenant name, inviter, expires_at) and \`POST /auth/accept-invite\` (takes token + password, sets password, clears token, logs user in).
- **middleware/tenant.py**: \`/auth/accept-invite\` added to \`_PUBLIC_PATHS\` and a new \`_PUBLIC_PREFIXES\` tuple for \`/auth/invite/\` so the public endpoints bypass tenant-scoped auth.
- **config/__init__.py**: new \`frontend_url\` setting (default \`https://app.listingjet.com\`) used to build the accept-invite link.

## Why login doesn't need an explicit pending-invite check

\`verify_password_constant_time\` already handles \`None\` by comparing against a pre-computed dummy hash, so a login attempt on a pending account falls through to the generic \"invalid email or password\" error. That's also the correct behavior from a security standpoint — giving a different error for pending invites would leak account state to attackers.

## Breaking change

Any existing client calling \`POST /team/members\` with a \`password\` field will need to update. The field is now simply ignored (Pydantic skips unknown fields). The backend response shape also changed from \`TeamMemberResponse\` to \`InviteTeamMemberResponse\` to include the invite expiry.

The frontend still POSTs a password in its current invite form — that's what Batch 2 fixes. Until Batch 2 ships, the frontend invite form will send an extra field the backend ignores (no-op). Admins won't be able to sign the invitee in directly anymore — they'll need to tell the invitee to check their email.

## Test plan

- [x] 17 new tests in \`test_team_invites.py\` covering:
  - Invite creates pending user with null password ✓
  - Invite sends email with accept link ✓
  - Duplicate email rejected ✓
  - Invalid role rejected ✓
  - Admin cannot escalate to superadmin ✓
  - Legacy \`password\` in body ignored ✓
  - \`GET /auth/invite/{token}\` happy path ✓
  - \`GET /auth/invite/{token}\` 404 for invalid token ✓
  - \`GET /auth/invite/{token}\` 410 for expired token ✓
  - \`POST /auth/accept-invite\` sets password, clears token, stamps consent ✓
  - Optional name override on accept ✓
  - Single-use: second accept returns 404 ✓
  - Expired accept returns 410 ✓
  - Min password length enforced (422) ✓
  - Pending user cannot log in ✓
  - Login succeeds after accept ✓
  - Team list exposes \`pending_invite\` flag ✓
- [x] Full \`tests/test_api/\` regression: 217 passed, 3 skipped
- [x] Ruff clean on all touched files
- [ ] **Migration runs cleanly** — verify \`alembic upgrade head\` succeeds on staging before shipping
- [ ] **Email delivery** — send a real invite to yourself on staging to confirm the template renders, links work, and the accept page round-trips
- [ ] **Existing users** — confirm no regression on the current team-list UI; pending users should now show with a flag, active users should be unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)