### PR TITLE
fix(ux): add dashboard escape hatch to error boundary (C004)

### DIFF
--- a/frontend/src/components/error-boundary.tsx
+++ b/frontend/src/components/error-boundary.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Component, type ReactNode } from "react";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
 interface Props {
@@ -42,7 +43,16 @@ export class ErrorBoundary extends Component<Props, State> {
             <p className="text-sm text-[var(--color-text-secondary)] mb-4">
               {this.state.error?.message || "An unexpected error occurred."}
             </p>
-            <Button onClick={this.handleReset}>Try Again</Button>
+            <div className="flex items-center justify-center gap-3">
+              <Button onClick={this.handleReset}>Try Again</Button>
+              <Link
+                href="/dashboard"
+                onClick={this.handleReset}
+                className="text-sm font-semibold text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors"
+              >
+                Go to Dashboard
+              </Link>
+            </div>
           </div>
         </div>
       );


### PR DESCRIPTION
## Summary

The last open item from the UX audit (C004). The original audit complaint was that the error boundary fallback \"renders just a blank area or a generic 'something went wrong' with no action\" — that was inaccurate. The fallback already has:

- A red icon
- \"Something went wrong\" heading
- The actual \`state.error?.message\`
- A \"Try Again\" button that resets \`hasError\`

The only real gap was a recovery path for when Try Again doesn't work. If a user lands in the fallback from a page that's fundamentally broken, resetting state just re-crashes and they're stuck with no way out short of a hard reload.

This PR adds a \"Go to Dashboard\" link next to the Try Again button. Click also resets \`hasError\` so navigation happens from a clean state.

## Changes

- \`frontend/src/components/error-boundary.tsx\` — added \`<Link href=\"/dashboard\">\` alongside the existing Try Again button
- Import of \`next/link\` added

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`eslint\` clean
- [ ] Manual: throw an error in a page component and verify the fallback shows both buttons side by side
- [ ] Manual: click Go to Dashboard from the fallback and verify it navigates to \`/dashboard\` (not a hard reload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)