### PR TITLE
fix(ux): analytics empty state + dashboard hero + listing-card modal + wizard optional

### DIFF
--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { motion } from "framer-motion";
 import { Nav } from "@/components/layout/nav";
 import { ProtectedRoute } from "@/components/layout/protected-route";
 import { GlassCard } from "@/components/ui/glass-card";
+import { EmptyState } from "@/components/ui/empty-state";
 import { TimelineChart } from "@/components/analytics/timeline-chart";
 import { StateBreakdown } from "@/components/analytics/state-breakdown";
 import { CreditHistory } from "@/components/analytics/credit-history";
@@ -120,6 +122,21 @@ function AnalyticsContent() {
 
         {tab === "performance" ? (
           <PerformanceIntelligence />
+        ) : overview?.total_listings === 0 ? (
+          <GlassCard tilt={false}>
+            <EmptyState
+              title="No data yet"
+              description="Analytics come to life once you've created your first listing. Create one now and come back to see pipeline, delivery, and credit trends."
+              action={
+                <Link
+                  href="/listings/new"
+                  className="px-5 py-2.5 rounded-full bg-[#F97316] hover:bg-[#ea580c] text-white font-semibold text-sm transition-colors shadow-md shadow-orange-200"
+                >
+                  Create your first listing
+                </Link>
+              }
+            />
+          </GlassCard>
         ) : (
           <>
             {/* Stat Cards */}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -203,6 +203,26 @@ function DashboardContent() {
           </div>
         </GlassCard>
 
+        {/* First-run hero CTA — promoted above the stat cards for new accounts */}
+        {listings.length === 0 && (
+          <GlassCard tilt={false}>
+            <EmptyState
+              icon={
+                <svg className="w-12 h-12 text-[#F97316]/40" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                </svg>
+              }
+              title="Ready for your first listing?"
+              description="Upload a few property photos and ListingJet's AI will generate MLS-ready marketing materials in minutes. No manual copywriting, no design software."
+              action={
+                <Link href="/listings/new">
+                  <Button variant="primary">Create your first listing</Button>
+                </Link>
+              }
+            />
+          </GlassCard>
+        )}
+
         {/* Stat Cards */}
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
           <motion.div

--- a/frontend/src/components/listings/creation-wizard/step-virtual-staging.tsx
+++ b/frontend/src/components/listings/creation-wizard/step-virtual-staging.tsx
@@ -40,15 +40,21 @@ export function StepVirtualStaging({ formData, onUpdate, onNext, onBack }: Props
 
   return (
     <GlassCard tilt={false}>
-      <h2
-        className="text-xl font-bold mb-2"
-        style={{ fontFamily: "var(--font-heading)" }}
-      >
-        Virtual Staging
-      </h2>
+      <div className="flex items-baseline gap-2 mb-2">
+        <h2
+          className="text-xl font-bold"
+          style={{ fontFamily: "var(--font-heading)" }}
+        >
+          Virtual Staging
+        </h2>
+        <span className="text-[10px] uppercase tracking-wider text-[var(--color-text-secondary)] font-semibold px-1.5 py-0.5 rounded-full border border-[var(--color-border)]">
+          Optional
+        </span>
+      </div>
       <p className="text-sm text-[var(--color-text-secondary)] mb-6">
-        Select photos you'd like virtually staged. Tap a photo to toggle it. Each
-        selected photo will have furniture and decor added by AI.
+        Select photos you&apos;d like virtually staged, or skip this step to
+        continue without staging. Each selected photo will have furniture and
+        decor added by AI.
       </p>
 
       {uploadedAssets.length === 0 ? (

--- a/frontend/src/components/listings/listing-card.tsx
+++ b/frontend/src/components/listings/listing-card.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { motion, AnimatePresence } from "framer-motion";
 import { Badge } from "@/components/ui/badge";
 import apiClient from "@/lib/api-client";
 import type { ListingResponse } from "@/lib/types";
@@ -111,43 +112,16 @@ export function ListingCard({ listing, onDeleted }: ListingCardProps) {
           )}
           <div className="flex items-center gap-2">
             {canDelete && (
-              confirming ? (
-                <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
-                  <button
-                    disabled={deleting}
-                    onClick={async (e) => {
-                      e.stopPropagation();
-                      setDeleting(true);
-                      try {
-                        await apiClient.deleteListing(listing.id);
-                        onDeleted?.(listing.id);
-                      } catch {
-                        setDeleting(false);
-                        setConfirming(false);
-                      }
-                    }}
-                    className="px-2 py-1 rounded-full bg-red-500 text-white text-[11px] font-semibold uppercase tracking-wide hover:bg-red-600 transition-colors disabled:opacity-50"
-                  >
-                    {deleting ? "..." : "Confirm"}
-                  </button>
-                  <button
-                    onClick={(e) => { e.stopPropagation(); setConfirming(false); }}
-                    className="px-2 py-1 rounded-full border border-slate-200 text-slate-400 text-[11px] font-semibold uppercase tracking-wide hover:border-slate-300 transition-colors"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              ) : (
-                <button
-                  onClick={(e) => { e.stopPropagation(); setConfirming(true); }}
-                  className="w-8 h-8 rounded-full border border-slate-200 flex items-center justify-center text-slate-400 hover:border-red-300 hover:text-red-500 transition-colors"
-                  title="Delete listing"
-                >
-                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                  </svg>
-                </button>
-              )
+              <button
+                onClick={(e) => { e.stopPropagation(); setConfirming(true); }}
+                className="w-8 h-8 rounded-full border border-slate-200 flex items-center justify-center text-slate-400 hover:border-red-300 hover:text-red-500 transition-colors"
+                title="Delete listing"
+                aria-label="Delete listing"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+              </button>
             )}
             {isDelivered ? (
               <button className="px-3 py-1 rounded-full bg-[#F97316] text-white text-[11px] font-semibold uppercase tracking-wide hover:bg-[#ea580c] transition-colors">
@@ -163,6 +137,88 @@ export function ListingCard({ listing, onDeleted }: ListingCardProps) {
           </div>
         </div>
       </div>
+
+      {/* Delete confirmation modal */}
+      <AnimatePresence>
+        {confirming && (
+          <motion.div
+            key="delete-modal"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={`delete-listing-title-${listing.id}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              if (!deleting) setConfirming(false);
+            }}
+          >
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95, y: 10 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.95, y: 10 }}
+              transition={{ duration: 0.15 }}
+              onClick={(e) => e.stopPropagation()}
+              className="w-full max-w-md rounded-2xl border border-slate-100 bg-white p-6 shadow-2xl"
+            >
+              <div className="flex items-start gap-3 mb-4">
+                <div className="w-10 h-10 rounded-full bg-red-500/10 flex items-center justify-center shrink-0">
+                  <svg className="w-5 h-5 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.268 16.5c-.77.833.192 2.5 1.732 2.5z" />
+                  </svg>
+                </div>
+                <div className="min-w-0 flex-1">
+                  <h3
+                    id={`delete-listing-title-${listing.id}`}
+                    className="text-base font-bold text-[var(--color-text)]"
+                    style={{ fontFamily: "var(--font-heading)" }}
+                  >
+                    Delete this listing?
+                  </h3>
+                  <p className="text-sm text-[var(--color-text-secondary)] mt-1">
+                    <span className="font-semibold text-[var(--color-text)]">
+                      {address.street || "Untitled listing"}
+                    </span>
+                    {address.city ? ` · ${address.city}` : ""} will be
+                    permanently deleted along with its photos, packages, and
+                    video assets. This cannot be undone.
+                  </p>
+                </div>
+              </div>
+              <div className="flex justify-end gap-2 mt-5">
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); setConfirming(false); }}
+                  disabled={deleting}
+                  className="px-4 py-2 rounded-lg text-sm font-semibold text-slate-500 border border-slate-200 hover:text-slate-700 transition-colors disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={async (e) => {
+                    e.stopPropagation();
+                    setDeleting(true);
+                    try {
+                      await apiClient.deleteListing(listing.id);
+                      onDeleted?.(listing.id);
+                    } catch {
+                      setDeleting(false);
+                      setConfirming(false);
+                    }
+                  }}
+                  disabled={deleting}
+                  className="px-4 py-2 rounded-lg text-sm font-semibold text-white bg-red-500 hover:bg-red-600 transition-colors disabled:opacity-50"
+                >
+                  {deleting ? "Deleting..." : "Delete"}
+                </button>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Four safe quick wins from the UX audit, all independent of each other and of the other open PRs.

### W003 — Analytics empty state

New tenants with zero listings used to see an Analytics page full of \"0\" stat cards and empty charts with no guidance. Added a branch: when \`overview?.total_listings === 0\`, the main content area renders a GlassCard with an \`EmptyState\` (\"No data yet — Analytics come to life once you've created your first listing\") and a \"Create your first listing\" button linking to \`/listings/new\`, instead of the zero-filled grid.

### W006 — Virtual staging wizard step is optional

The wizard's step 3 already had a Skip button, but nothing told the user the step itself was optional — users felt blocked. Added an \"Optional\" pill next to the step heading and rewrote the subtitle to mention the skip path: \"Select photos you'd like virtually staged, **or skip this step to continue without staging**.\"

### S001 — Dashboard first-run hero CTA

The dashboard greeted new users with zero-filled stat cards and buried the \"Create first listing\" CTA inside the Recent Listings column below. Added a prominent full-width \`EmptyState\` card between the Credit Hero and the stat cards when \`listings.length === 0\`, with a \"Create your first listing\" CTA. The secondary EmptyState in the Recent Listings column stays as a backup surface.

### S002 — Listing card delete modal

Replaced the inline \"Confirm / Cancel\" pill reveal on the listing card with a proper modal dialog that names the listing address and explains exactly what gets deleted (photos, packages, video assets, cannot be undone). Modal has an icon, explicit Cancel and Delete buttons, disables during the API call, closes on backdrop click. Matches the pattern already used by the team-member removal modal from PR #206.

## Already-done items verified while sweeping the audit

| Item | Status |
|---|---|
| C001 active nav styling | Fixed previously |
| C002 listing detail page title | Fixed in #204 |
| C003 password-in-invite | Fixed in #205 + #206 |
| C004 error boundary fallback | Fixed in #207 |
| W002 onboarding redirect | Already done |
| W005 support error swallow | Fixed in #204 |
| W008 404 page | Already has Go home + Dashboard |
| W009 listings page error state | Already rendered |
| S005 forgot-password feedback | Already shows inline confirmation |

## Deferred because they need design decisions

| Item | Why it's deferred |
|---|---|
| **W001** nav grouping | Need to pick which 8+ nav items are primary vs secondary — that's a design call, not a safe refactor |
| **W007** settings sub-nav | Requires new routes + layout file + navigation decisions (Brand Kit, Team, Connected Accounts, Language) |
| **W004** CMA/microsite silent \`.catch\` | Low priority — on the listing detail page the fallback \"Generate\" button will surface the same error on retry, so the silent catch during initial prefetch is actually fine UX |
| **S003** /billing vs /pricing | Need to know whether \`/pricing\` is still needed post-login or can be removed/redirected |
| **S004** /review page access gating | Need to know intended audience (internal-only staff, or all admins?) |
| **S006** social post hub entry point | Need to see how current entry point reads and whether the labeling is the real issue |

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`eslint\` clean on touched files (one pre-existing \`<img>\` warning in virtual-staging step unrelated to this PR)
- [ ] Manual: fresh account, confirm the dashboard shows the hero CTA above the stat cards
- [ ] Manual: fresh account, visit /analytics, confirm the empty state renders with the CTA instead of zero-filled charts
- [ ] Manual: start the creation wizard, confirm step 3 shows the Optional pill and subtitle mentions skip
- [ ] Manual: click the trash icon on a listing card, confirm the modal opens with the address, confirm Cancel and backdrop-click close it, confirm Delete works

🤖 Generated with [Claude Code](https://claude.com/claude-code)