### PR TITLE
docs(todo): log UX audit deferred items + session verification TODOs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,20 @@
 # ListingJet — Deferred Items
 
-Items from the code quality audit that need design decisions, larger refactors, or are low priority.
+Items from the code quality audit and UX audit that need design decisions, larger refactors, or are low priority.
 
 ## Needs Design Decision
 
 - **Dual credit systems (Audit #8):** `CreditAccount` table vs `Tenant.credit_balance` — two sources of truth for credit balance. Need product decision on which is canonical. `CreditService` uses `CreditAccount`; admin API uses `Tenant.credit_balance`. Risk: balances diverge.
+
+- **Nav grouping (UX W001):** Authenticated nav has 8+ top-level links with no hierarchy. Group into primary (Dashboard, Listings) and secondary/utility (Analytics, Billing, Settings, Support, Changelog) with a separator, or move Help items into a dropdown. Need design call on which items are primary.
+
+- **Settings sub-nav (UX W007):** `/settings` and `/settings/team` are separate top-level routes with no sidebar between them. A persistent settings sidebar in `settings/layout.tsx` (Brand Kit, Team, Connected Accounts, Language) would unify navigation. Needs layout + route decisions.
+
+- **Billing vs pricing route duplication (UX S003):** Both `/billing` and `/pricing` exist. Need product decision on whether `/pricing` is still needed post-auth, or should be removed/redirected for logged-in users.
+
+- **Review page access gating (UX S004):** `/review` exists but intended audience is unclear. If internal/staff-only, gate behind a role check at the route level rather than relying on API 403s.
+
+- **Social post hub entry point (UX S006):** Social workflow is accessible from the listing detail page AND via a separate route. Labeling and primary entry point need a decision.
 
 ## Needs Larger Refactor
 
@@ -27,3 +37,21 @@ Items from the code quality audit that need design decisions, larger refactors, 
 - **Cancel listing reuses FAILED state (Audit #16):** Response returns `"state": "cancelled"` but `ListingState` has no `CANCELLED` value. Should add `CANCELLED` enum value or honestly return `"failed"`.
 
 - **Brand Kit migration gap (Audit #22):** `brand_kit.py` model referenced in migration 011 but migration numbering/chain should be verified.
+
+- **CMA / microsite silent `.catch` on listing detail (UX W004):** `listings/[id]/page.tsx:64-65` swallows errors on initial prefetch via `.catch(() => {})`. Low priority because the fallback \"Generate\" button resurfaces the same error on retry, but could be made explicit if a user-visible failure indicator is desired.
+
+- **Error boundary dashboard link (UX C004):** Mostly shipped in PR #207, but the audit's concern about \"no recovery path\" was inaccurate — the Try Again button already existed. The dashboard link was a 3-line addition. No further action needed unless specific pages want their own fallback.
+
+## Pending Verification
+
+- **Dollhouse render on real listings (PR #201 merged):** The `DollhouseRenderAgent` was shipped but hasn't been run against a real floorplan + room photos yet. When a listing with a real floorplan is available, run the pipeline and inspect the generated PNG at `listings/{id}/dollhouse.png`. The gpt-image-1.5 prompt in `src/listingjet/providers/openai_dollhouse.py:26` is a first cut and will likely want tuning after the first real output is reviewed.
+
+- **Virtual staging + object removal real output (PR #202):** Switched from DALL-E 3 text-only to gpt-image-1.5 with real image input. Before merging, eye a sample of both `stage_image()` and `remove_object()` output on real photos — the model will behave differently than the current broken hallucination.
+
+- **Team invite email template (PR #205):** The `team_member_invite` HTML template in `services/email_templates.py` is a first cut. Send yourself a real invite on staging after #205 merges to verify it renders correctly in a real inbox and the accept link round-trips through #206's frontend.
+
+## Housekeeping
+
+- **Untracked session handoff docs:** `docs/SESSION-HANDOFF-2026-04-07-deploy.md`, `docs/SESSION-HANDOFF-2026-04-07.md`, `docs/SESSION-HANDOFF-VIDEO-QUALITY.md` — historical records of already-shipped PRs. Either commit to `docs/archive/` or delete.
+
+- **Untracked operational docs:** `docs/runbooks/secret-rotation.md` (valuable active runbook) and `scripts/smoke_resend.py` (useful email smoke test) should be committed. `frontend/UX_AUDIT.md` should either be committed as document-of-record or deleted since most items are now resolved.


### PR DESCRIPTION
## Summary

Wraps up the 2026-04-10 session by logging deferred items that need design decisions, larger refactors, or manual verification.

### New in TODO.md

**Needs Design Decision:**
- W001 nav grouping
- W007 settings sub-nav
- S003 billing vs pricing duplication
- S004 review page access gating
- S006 social post hub entry point

**Low Priority Cleanup:**
- W004 CMA/microsite silent \`.catch\` on listing detail
- C004 error boundary (mostly shipped in #207)

**Pending Verification (new section):**
- Dollhouse render on real listings (PR #201 merged, untested on real data)
- Virtual staging + remove_object real output (PR #202)
- Team invite email template (PR #205)

**Housekeeping (new section):**
- Untracked session handoff docs
- \`docs/runbooks/secret-rotation.md\` + \`scripts/smoke_resend.py\` worth committing

Everything that shipped today (C001-C004 criticals, W002/W003/W005/W006/W008/W009 warnings, S001/S002/S005 suggestions, C003 invite-token flow) is omitted — those are in PRs #202-#208.

## Test plan

- [x] Docs-only change, no code touched
- [x] File compiles as markdown
- [ ] Merge after review

🤖 Generated with [Claude Code](https://claude.com/claude-code)