### PR TITLE
feat(cma): real comparables via Repliers API with synthetic fallback

### DIFF
--- a/frontend/src/app/listings/[id]/page.tsx
+++ b/frontend/src/app/listings/[id]/page.tsx
@@ -12,6 +12,7 @@ import { PipelineStatus } from "@/components/listings/pipeline-status";
 import { AssetUploadForm } from "@/components/listings/asset-upload-form";
 import apiClient from "@/lib/api-client";
 import { useToast } from "@/components/ui/toast";
+import { useAuth } from "@/contexts/auth-context";
 import type { ListingResponse, AssetResponse, PackageSelection } from "@/lib/types";
 import { VideoPlayer } from "@/components/listings/video-player";
 import { VideoUpload } from "@/components/listings/video-upload";
@@ -26,6 +27,11 @@ function ListingDetail() {
   const params = useParams();
   const id = params.id as string;
   const { toast } = useToast();
+  const { user } = useAuth();
+  // CMA uses a paid external data source (Repliers, ~$200/mo minimum). While
+  // the feature runs on the synthetic fallback, we gate it to superadmins so
+  // staff can still demo/QA without exposing unverified comps to paying users.
+  const isSuperadmin = user?.role === "superadmin";
 
   const [listing, setListing] = useState<ListingResponse | null>(null);
   const [assets, setAssets] = useState<AssetResponse[]>([]);
@@ -59,9 +65,11 @@ function ListingDetail() {
         const pkg = await apiClient.getPackage(id);
         setSelections(pkg);
       }
-      // Load CMA and microsite if listing is far enough along
+      // Load CMA (superadmin-gated) and microsite if listing is far enough along
       if (["approved", "exporting", "delivered"].includes(l.state)) {
-        apiClient.getCMAReport(id).then(setCmaReport).catch(() => {});
+        if (isSuperadmin) {
+          apiClient.getCMAReport(id).then(setCmaReport).catch(() => {});
+        }
         apiClient.getMicrosite(id).then(setMicrosite).catch(() => {});
       }
     } catch (err: unknown) {
@@ -70,7 +78,7 @@ function ListingDetail() {
     } finally {
       setLoading(false);
     }
-  }, [id]);
+  }, [id, isSuperadmin]);
 
   useEffect(() => {
     const street = listing?.address?.street;
@@ -528,44 +536,54 @@ function ListingDetail() {
               </button>
             </div>
 
-            {/* CMA Report */}
-            <div className="bg-white rounded-2xl border border-slate-100 p-5">
-              <h3 className="text-sm font-semibold text-[var(--color-text)] mb-2" style={{ fontFamily: "var(--font-heading)" }}>
-                CMA Report
-              </h3>
-              {cmaReport ? (
-                <div className="space-y-2">
-                  <p className="text-xs text-[var(--color-text-secondary)]">
-                    {cmaReport.comparables_count} comparables &middot; Generated {new Date(cmaReport.generated_at).toLocaleDateString()}
-                  </p>
-                  <a
-                    href={cmaReport.download_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-block w-full text-center px-4 py-2 rounded-lg bg-[#F97316] hover:bg-[#ea580c] text-white text-xs font-semibold transition-colors"
-                  >
-                    Download Report
-                  </a>
+            {/* CMA Report — superadmin-only until we're off the synthetic fallback */}
+            {isSuperadmin && (
+              <div className="bg-white rounded-2xl border border-slate-100 p-5">
+                <div className="flex items-center justify-between mb-2">
+                  <h3 className="text-sm font-semibold text-[var(--color-text)]" style={{ fontFamily: "var(--font-heading)" }}>
+                    CMA Report
+                  </h3>
+                  <span className="text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded bg-amber-100 text-amber-800">
+                    Staff preview
+                  </span>
                 </div>
-              ) : (
-                <button
-                  onClick={async () => {
-                    setCmaLoading(true);
-                    try {
-                      await apiClient.generateCMAReport(id);
-                      const report = await apiClient.getCMAReport(id);
-                      setCmaReport(report);
-                      toast("CMA report generated", "success");
-                    } catch { toast("CMA generation failed", "error"); }
-                    finally { setCmaLoading(false); }
-                  }}
-                  disabled={cmaLoading}
-                  className="w-full px-4 py-2 rounded-lg bg-[#F97316] hover:bg-[#ea580c] text-white text-xs font-semibold transition-colors disabled:opacity-50"
-                >
-                  {cmaLoading ? "Generating..." : "Generate CMA Report"}
-                </button>
-              )}
-            </div>
+                <p className="text-[11px] text-[var(--color-text-secondary)] mb-3">
+                  Using synthetic comparables — real MLS data unlocks once we activate Repliers.
+                </p>
+                {cmaReport ? (
+                  <div className="space-y-2">
+                    <p className="text-xs text-[var(--color-text-secondary)]">
+                      {cmaReport.comparables_count} comparables &middot; Generated {new Date(cmaReport.generated_at).toLocaleDateString()}
+                    </p>
+                    <a
+                      href={cmaReport.download_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-block w-full text-center px-4 py-2 rounded-lg bg-[#F97316] hover:bg-[#ea580c] text-white text-xs font-semibold transition-colors"
+                    >
+                      Download Report
+                    </a>
+                  </div>
+                ) : (
+                  <button
+                    onClick={async () => {
+                      setCmaLoading(true);
+                      try {
+                        await apiClient.generateCMAReport(id);
+                        const report = await apiClient.getCMAReport(id);
+                        setCmaReport(report);
+                        toast("CMA report generated", "success");
+                      } catch { toast("CMA generation failed", "error"); }
+                      finally { setCmaLoading(false); }
+                    }}
+                    disabled={cmaLoading}
+                    className="w-full px-4 py-2 rounded-lg bg-[#F97316] hover:bg-[#ea580c] text-white text-xs font-semibold transition-colors disabled:opacity-50"
+                  >
+                    {cmaLoading ? "Generating..." : "Generate CMA Report"}
+                  </button>
+                )}
+              </div>
+            )}
 
             {/* Property Microsite */}
             <div className="bg-white rounded-2xl border border-slate-100 p-5">

--- a/src/listingjet/agents/cma_report.py
+++ b/src/listingjet/agents/cma_report.py
@@ -14,6 +14,7 @@ from listingjet.models.cma_report import CMAReport
 from listingjet.models.listing import Listing
 from listingjet.models.property_data import PropertyData
 from listingjet.providers import get_llm_provider
+from listingjet.services.comparables import ComparablesService
 from listingjet.services.pii_filter import sanitize_for_prompt
 from listingjet.services.storage import StorageService
 
@@ -87,10 +88,17 @@ class CMAReportAgent(BaseAgent):
     agent_name = "cma_report"
     requires_ai_consent = True
 
-    def __init__(self, llm_provider=None, storage_service=None, session_factory=None):
+    def __init__(
+        self,
+        llm_provider=None,
+        storage_service=None,
+        session_factory=None,
+        comparables_service: ComparablesService | None = None,
+    ):
         self._llm = llm_provider or get_llm_provider(agent=self.agent_name)
         self._storage = storage_service or StorageService()
         self._session_factory = session_factory or AsyncSessionLocal
+        self._comparables = comparables_service or ComparablesService()
 
     async def execute(self, context: AgentContext) -> dict:
         async with self.session_scope(context) as (session, listing_id, tenant_id):
@@ -117,9 +125,8 @@ class CMAReportAgent(BaseAgent):
                 "price": meta.get("price"),
             }
 
-            # Generate synthetic comparables from property data
-            # In production, this would call ATTOM historical sales API or scrapers
-            comparables = self._generate_comparables(subject)
+            # Fetch comparables — Repliers if enabled + configured, synthetic fallback otherwise.
+            comparables = await self._comparables.fetch(subject)
 
             # Generate analysis narrative via LLM
             comps_text = "\n".join(
@@ -191,42 +198,3 @@ class CMAReportAgent(BaseAgent):
             })
 
         return {"comparables_count": len(comparables), "s3_key": s3_key}
-
-    def _generate_comparables(self, subject: dict) -> list[dict]:
-        """Generate comparable sales data.
-
-        In production, this would query ATTOM historical sales API or
-        enhanced scrapers. For now, generates realistic synthetic data
-        based on the subject property's attributes.
-        """
-        import random
-
-        base_sqft = subject.get("sqft") or 1800
-        base_price = subject.get("price") or 400_000
-        base_beds = subject.get("beds") or 3
-        base_baths = subject.get("baths") or 2
-        base_ppsf = base_price / base_sqft if base_sqft > 0 else 220
-
-        streets = [
-            "Oak Ave", "Maple Dr", "Pine St", "Cedar Ln", "Elm Blvd",
-            "Birch Ct", "Willow Way", "Ash Rd",
-        ]
-        city = subject.get("address", "").split(",")[1].strip() if "," in subject.get("address", "") else "Austin"
-
-        comps = []
-        for i in range(6):
-            sqft_delta = random.randint(-200, 200)
-            sqft = max(800, base_sqft + sqft_delta)
-            ppsf = round(base_ppsf + random.uniform(-30, 30), 2)
-            price = round(sqft * ppsf / 1000) * 1000
-
-            comps.append({
-                "address": f"{random.randint(100, 999)} {streets[i]}, {city}",
-                "beds": base_beds + random.choice([-1, 0, 0, 1]),
-                "baths": base_baths + random.choice([-0.5, 0, 0, 0.5]),
-                "sqft": sqft,
-                "price": price,
-                "price_per_sqft": ppsf,
-            })
-
-        return comps

--- a/src/listingjet/api/cma.py
+++ b/src/listingjet/api/cma.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from listingjet.api.deps import get_current_user, get_db
+from listingjet.api.deps import get_db, require_superadmin
 from listingjet.models.cma_report import CMAReport
 from listingjet.models.listing import Listing
 from listingjet.models.user import User
@@ -31,10 +31,15 @@ class CMAReportResponse(BaseModel):
 async def generate_cma_report(
     listing_id: uuid.UUID,
     _rl=Depends(rate_limit(5, 60)),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_superadmin),
     db: AsyncSession = Depends(get_db),
 ):
-    """Generate a CMA report for a listing. Runs synchronously (typically <30s)."""
+    """Generate a CMA report for a listing.
+
+    Superadmin-gated while Repliers is on the synthetic/fallback path — the
+    feature will open to tenant users once we move off the synthetic comparables
+    and start paying for real MLS data.
+    """
     listing = (await db.execute(
         select(Listing).where(
             Listing.id == listing_id,
@@ -57,10 +62,10 @@ async def generate_cma_report(
 @router.get("/{listing_id}/cma-report")
 async def get_cma_report(
     listing_id: uuid.UUID,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_superadmin),
     db: AsyncSession = Depends(get_db),
 ):
-    """Retrieve the most recent CMA report for a listing."""
+    """Retrieve the most recent CMA report for a listing. Superadmin-only (see POST)."""
     report = (await db.execute(
         select(CMAReport).where(
             CMAReport.listing_id == listing_id,

--- a/src/listingjet/config/__init__.py
+++ b/src/listingjet/config/__init__.py
@@ -193,5 +193,12 @@ class Settings(BaseSettings):
     property_verification_enabled: bool = True
     scraper_rate_limit_seconds: int = 5
 
+    # Repliers (MLS data aggregator — https://docs.repliers.io)
+    # Used for real CMA comparables; falls back to synthetic data when unset.
+    repliers_api_key: str = ""
+    repliers_api_base: str = "https://api.repliers.io"
+    repliers_cma_enabled: bool = False
+    repliers_timeout_seconds: int = 10
+
 
 settings = Settings()

--- a/src/listingjet/providers/repliers.py
+++ b/src/listingjet/providers/repliers.py
@@ -1,0 +1,166 @@
+# src/listingjet/providers/repliers.py
+"""
+Repliers provider — MLS data aggregator (https://docs.repliers.io).
+
+Used by services/comparables.py to fetch real comparable sales for CMA reports.
+Repliers pricing is per-MLS-system licensed, so calls are feature-flagged via
+`settings.repliers_cma_enabled` and gracefully degrade when the flag is off or
+the API key is missing.
+
+Only the endpoints we actually need are implemented:
+  - search_listings(filters)          — GET /listings with filter params
+  - get_similar(mls_number, limit)    — GET /listings/{mlsNumber}/similar
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from listingjet.config import settings
+from listingjet.services.metrics import record_provider_call
+
+logger = logging.getLogger(__name__)
+
+# Repliers API returns listings under a top-level "listings" key; each record
+# has a nested shape like:
+# {
+#   "mlsNumber": "C1234567",
+#   "listPrice": 850000,
+#   "soldPrice": 835000,
+#   "address": {"streetNumber": "123", "streetName": "Oak", "streetSuffix": "Ave",
+#               "city": "Austin", "state": "TX", "zip": "78701"},
+#   "details": {"numBedrooms": 3, "numBathrooms": 2, "sqft": 1800, "yearBuilt": 2010,
+#                "propertyType": "Residential"},
+#   "soldDate": "2024-11-04",
+#   "status": "Sld",
+#   ...
+# }
+# We normalize this to a dict shape the CMA agent already understands.
+
+
+class RepliersClient:
+    """Thin async wrapper around the Repliers REST API."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: int | None = None,
+    ):
+        self._api_key = api_key if api_key is not None else settings.repliers_api_key
+        self._base_url = (base_url or settings.repliers_api_base).rstrip("/")
+        self._timeout = timeout or settings.repliers_timeout_seconds
+
+    @property
+    def configured(self) -> bool:
+        """True if the client has an API key and can make real calls."""
+        return bool(self._api_key)
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "REPLIERS-API-KEY": self._api_key,
+            "Accept": "application/json",
+        }
+
+    async def search_listings(self, filters: dict[str, Any]) -> list[dict]:
+        """GET /listings with the given filter params.
+
+        Typical filters for comparables lookup:
+            {
+              "status": "Sld",            # sold only
+              "minBedrooms": 2,
+              "maxBedrooms": 4,
+              "minSqft": 1600,
+              "maxSqft": 2000,
+              "city": "Austin",
+              "state": "TX",
+              "soldSince": "2024-01-01",  # last 12 months
+              "pageSize": 10,
+            }
+        """
+        if not self.configured:
+            return []
+
+        url = f"{self._base_url}/listings"
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                resp = await client.get(url, params=filters, headers=self._headers())
+                resp.raise_for_status()
+                data = resp.json()
+                record_provider_call("repliers", True)
+                return data.get("listings", []) or []
+        except Exception:
+            logger.warning("repliers.search_listings failed filters=%s", filters)
+            record_provider_call("repliers", False)
+            return []
+
+    async def get_similar(self, mls_number: str, limit: int = 10) -> list[dict]:
+        """GET /listings/{mlsNumber}/similar — comparable listings for a known MLS #."""
+        if not self.configured:
+            return []
+
+        url = f"{self._base_url}/listings/{mls_number}/similar"
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                resp = await client.get(
+                    url,
+                    params={"pageSize": limit},
+                    headers=self._headers(),
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                record_provider_call("repliers", True)
+                return data.get("listings", []) or []
+        except Exception:
+            logger.warning("repliers.get_similar failed mls=%s", mls_number)
+            record_provider_call("repliers", False)
+            return []
+
+
+def normalize_listing(raw: dict) -> dict | None:
+    """Convert a raw Repliers listing into the dict shape CMAReportAgent expects.
+
+    Returns None if the listing is missing essential fields (price + sqft).
+    """
+    details = raw.get("details") or {}
+    address = raw.get("address") or {}
+
+    # Prefer sold price → close price → list price
+    price = raw.get("soldPrice") or raw.get("closePrice") or raw.get("listPrice")
+    sqft = details.get("sqft") or details.get("squareFeet")
+    if not price or not sqft:
+        return None
+
+    try:
+        price_int = int(float(price))
+        sqft_int = int(float(sqft))
+    except (ValueError, TypeError):
+        return None
+
+    if sqft_int <= 0:
+        return None
+
+    beds = details.get("numBedrooms") or details.get("beds")
+    baths = details.get("numBathrooms") or details.get("baths")
+
+    street_parts = [
+        address.get("streetNumber"),
+        address.get("streetName"),
+        address.get("streetSuffix"),
+    ]
+    street = " ".join(str(p).strip() for p in street_parts if p)
+    city = address.get("city", "")
+    full_address = f"{street}, {city}".strip(", ")
+
+    return {
+        "address": full_address or "—",
+        "beds": int(beds) if beds is not None else None,
+        "baths": float(baths) if baths is not None else None,
+        "sqft": sqft_int,
+        "price": price_int,
+        "price_per_sqft": round(price_int / sqft_int, 2),
+        "sold_date": raw.get("soldDate") or raw.get("closeDate"),
+        "mls_number": raw.get("mlsNumber"),
+    }

--- a/src/listingjet/services/comparables.py
+++ b/src/listingjet/services/comparables.py
@@ -1,0 +1,207 @@
+"""
+Comparables service — source of truth for CMA comparable-sales lookup.
+
+Tries Repliers first (when configured + feature-flagged on), falls back to
+synthetic data otherwise. The return shape matches what CMAReportAgent
+expects so the downstream LLM prompt and HTML template are unchanged.
+
+Returned dict shape per comparable::
+
+    {
+        "address": "123 Oak Ave, Austin",
+        "beds": 3,
+        "baths": 2.0,
+        "sqft": 1800,
+        "price": 425000,
+        "price_per_sqft": 236.11,
+        # Optional when sourced from Repliers:
+        "sold_date": "2024-11-04",
+        "mls_number": "C1234567",
+    }
+"""
+from __future__ import annotations
+
+import logging
+import random
+
+from listingjet.config import settings
+from listingjet.providers.repliers import RepliersClient, normalize_listing
+
+logger = logging.getLogger(__name__)
+
+# How many comparables we want to return from a single lookup.
+TARGET_COMP_COUNT = 6
+
+# Search window around the subject property — keeps comps relevant.
+SQFT_WINDOW_PCT = 0.20    # ±20% of subject sqft
+BED_WINDOW = 1            # ±1 bedroom
+
+
+class ComparablesService:
+    """Fetches comparable sales, Repliers-first with synthetic fallback."""
+
+    def __init__(self, repliers_client: RepliersClient | None = None):
+        self._repliers = repliers_client or RepliersClient()
+
+    async def fetch(self, subject: dict) -> list[dict]:
+        """Return comparables for the subject property.
+
+        Args:
+            subject: dict with keys address, beds, baths, sqft, year_built,
+                     property_type, price (all optional but more = better).
+
+        Returns:
+            A list of comparable dicts. Never raises — on any failure we fall
+            back to synthetic data so the CMA report always has something to
+            render.
+        """
+        if settings.repliers_cma_enabled and self._repliers.configured:
+            try:
+                comps = await self._fetch_from_repliers(subject)
+                if comps:
+                    logger.info(
+                        "comparables.repliers_hit count=%d subject_city=%s",
+                        len(comps), _extract_city(subject),
+                    )
+                    return comps
+                logger.info(
+                    "comparables.repliers_empty subject_city=%s — falling back",
+                    _extract_city(subject),
+                )
+            except Exception:
+                logger.exception("comparables.repliers_error — falling back to synthetic")
+
+        return self._synthetic_comparables(subject)
+
+    # ------------------------------------------------------------------
+    # Repliers path
+    # ------------------------------------------------------------------
+
+    async def _fetch_from_repliers(self, subject: dict) -> list[dict]:
+        filters = _build_filters(subject)
+        if filters is None:
+            # Not enough info to form a meaningful query — skip Repliers.
+            return []
+
+        raw_listings = await self._repliers.search_listings(filters)
+
+        comps: list[dict] = []
+        for raw in raw_listings:
+            normalized = normalize_listing(raw)
+            if normalized is not None:
+                comps.append(normalized)
+            if len(comps) >= TARGET_COMP_COUNT:
+                break
+        return comps
+
+    # ------------------------------------------------------------------
+    # Synthetic fallback (moved out of CMAReportAgent so it has one home)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _synthetic_comparables(subject: dict) -> list[dict]:
+        """Deterministic-ish synthetic comps based on the subject's attributes.
+
+        Copied from the old CMAReportAgent._generate_comparables() — kept as
+        a fallback so the CMA report always renders even when Repliers is off.
+        """
+        base_sqft = subject.get("sqft") or 1800
+        base_price = subject.get("price") or 400_000
+        base_beds = subject.get("beds") or 3
+        base_baths = subject.get("baths") or 2
+        base_ppsf = base_price / base_sqft if base_sqft > 0 else 220
+
+        streets = [
+            "Oak Ave", "Maple Dr", "Pine St", "Cedar Ln", "Elm Blvd",
+            "Birch Ct", "Willow Way", "Ash Rd",
+        ]
+        city = _extract_city(subject) or "Austin"
+
+        comps = []
+        for i in range(TARGET_COMP_COUNT):
+            sqft_delta = random.randint(-200, 200)
+            sqft = max(800, base_sqft + sqft_delta)
+            ppsf = round(base_ppsf + random.uniform(-30, 30), 2)
+            price = round(sqft * ppsf / 1000) * 1000
+
+            comps.append({
+                "address": f"{random.randint(100, 999)} {streets[i]}, {city}",
+                "beds": base_beds + random.choice([-1, 0, 0, 1]),
+                "baths": base_baths + random.choice([-0.5, 0, 0, 0.5]),
+                "sqft": sqft,
+                "price": price,
+                "price_per_sqft": ppsf,
+            })
+
+        return comps
+
+
+# ----------------------------------------------------------------------
+# Pure helpers (module-level so they're easy to unit-test)
+# ----------------------------------------------------------------------
+
+def _extract_city(subject: dict) -> str:
+    """Pull a city out of the subject dict; handles both address-string and dict forms."""
+    address = subject.get("address")
+    if isinstance(address, str) and "," in address:
+        parts = [p.strip() for p in address.split(",")]
+        if len(parts) >= 2:
+            return parts[1]
+    if isinstance(address, dict):
+        return address.get("city", "") or ""
+    return ""
+
+
+def _extract_state(subject: dict) -> str:
+    address = subject.get("address")
+    if isinstance(address, str):
+        parts = [p.strip() for p in address.split(",")]
+        if len(parts) >= 3:
+            # "street, city, state [zip]" — grab just the state token
+            return parts[2].split()[0] if parts[2] else ""
+    if isinstance(address, dict):
+        return address.get("state", "") or ""
+    return ""
+
+
+def _build_filters(subject: dict) -> dict | None:
+    """Build Repliers /listings query params from a subject dict.
+
+    Returns None if there's not enough info to form a meaningful query.
+    """
+    city = _extract_city(subject)
+    state = _extract_state(subject)
+    if not city:
+        return None
+
+    filters: dict = {
+        "status": "Sld",
+        "city": city,
+        "pageSize": TARGET_COMP_COUNT * 2,  # over-fetch — some will fail normalization
+    }
+    if state:
+        filters["state"] = state
+
+    sqft = subject.get("sqft")
+    if sqft:
+        try:
+            sqft_int = int(sqft)
+            filters["minSqft"] = int(sqft_int * (1 - SQFT_WINDOW_PCT))
+            filters["maxSqft"] = int(sqft_int * (1 + SQFT_WINDOW_PCT))
+        except (ValueError, TypeError):
+            pass
+
+    beds = subject.get("beds")
+    if beds:
+        try:
+            beds_int = int(beds)
+            filters["minBedrooms"] = max(1, beds_int - BED_WINDOW)
+            filters["maxBedrooms"] = beds_int + BED_WINDOW
+        except (ValueError, TypeError):
+            pass
+
+    prop_type = subject.get("property_type")
+    if prop_type:
+        filters["propertyType"] = prop_type
+
+    return filters

--- a/tests/test_agents/test_cma_report.py
+++ b/tests/test_agents/test_cma_report.py
@@ -1,0 +1,125 @@
+"""Tests for CMAReportAgent — ensures ComparablesService output reaches the HTML."""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import select
+
+from listingjet.agents.base import AgentContext
+from listingjet.agents.cma_report import CMAReportAgent
+from listingjet.models.cma_report import CMAReport
+from tests.test_agents.conftest import make_session_factory
+
+
+def _real_comps() -> list[dict]:
+    """Dict shape produced by ComparablesService (either path)."""
+    return [
+        {
+            "address": "456 Pine St, Austin",
+            "beds": 3,
+            "baths": 2.0,
+            "sqft": 1750,
+            "price": 425_000,
+            "price_per_sqft": 242.86,
+            "sold_date": "2024-11-04",
+            "mls_number": "C1234567",
+        },
+        {
+            "address": "789 Maple Dr, Austin",
+            "beds": 3,
+            "baths": 2.5,
+            "sqft": 1900,
+            "price": 465_000,
+            "price_per_sqft": 244.74,
+            "sold_date": "2024-10-15",
+            "mls_number": "C7654321",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cma_agent_uses_injected_comparables_service(db_session, listing):
+    """Injected ComparablesService output flows into comparables_count + HTML + LLM prompt."""
+    comps = _real_comps()
+
+    mock_comparables = MagicMock()
+    mock_comparables.fetch = AsyncMock(return_value=comps)
+
+    mock_llm = MagicMock()
+    mock_llm.complete = AsyncMock(return_value="Market is healthy. Price $450k–$470k.")
+
+    mock_storage = MagicMock()
+    mock_storage.upload = MagicMock()
+
+    agent = CMAReportAgent(
+        llm_provider=mock_llm,
+        storage_service=mock_storage,
+        session_factory=make_session_factory(db_session),
+        comparables_service=mock_comparables,
+    )
+
+    ctx = AgentContext(listing_id=str(listing.id), tenant_id=str(listing.tenant_id))
+    result = await agent.execute(ctx)
+
+    # Service was called with the subject derived from the listing
+    mock_comparables.fetch.assert_awaited_once()
+    subject_arg = mock_comparables.fetch.call_args.args[0]
+    assert "Austin" in subject_arg["address"]
+    assert subject_arg["beds"] == 3
+
+    # Comparables flowed through into the result and the DB row
+    assert result["comparables_count"] == 2
+    assert result["s3_key"].startswith(f"listings/{listing.id}/cma-report-")
+
+    await db_session.flush()
+    report = (await db_session.execute(
+        select(CMAReport).where(CMAReport.listing_id == listing.id)
+    )).scalar_one()
+    assert report.comparables_count == 2
+    assert report.comparables[0]["mls_number"] == "C1234567"
+    assert report.comparables[1]["mls_number"] == "C7654321"
+
+    # Storage was called with HTML containing both MLS-sourced addresses
+    upload_call = mock_storage.upload.call_args
+    html_bytes = upload_call.args[1]
+    html = html_bytes.decode("utf-8")
+    assert "456 Pine St, Austin" in html
+    assert "789 Maple Dr, Austin" in html
+    assert "$425,000" in html
+    assert "$465,000" in html
+
+    # LLM prompt included the real comps, not the synthetic ones
+    prompt_arg = mock_llm.complete.call_args.kwargs.get("prompt") or mock_llm.complete.call_args.args[0]
+    assert "456 Pine St, Austin" in prompt_arg
+    assert "sold $425,000" in prompt_arg
+
+
+@pytest.mark.asyncio
+async def test_cma_agent_falls_back_to_service_when_no_repliers(db_session, listing):
+    """When ComparablesService returns synthetic comps, the agent still produces a valid report."""
+    from listingjet.services.comparables import ComparablesService
+
+    # Use the real service but with an unconfigured Repliers client → hits synthetic path.
+    from listingjet.providers.repliers import RepliersClient
+    real_service = ComparablesService(
+        repliers_client=RepliersClient(api_key="", base_url="https://fake"),
+    )
+
+    mock_llm = MagicMock()
+    mock_llm.complete = AsyncMock(return_value="Narrative.")
+
+    mock_storage = MagicMock()
+    mock_storage.upload = MagicMock()
+
+    agent = CMAReportAgent(
+        llm_provider=mock_llm,
+        storage_service=mock_storage,
+        session_factory=make_session_factory(db_session),
+        comparables_service=real_service,
+    )
+
+    ctx = AgentContext(listing_id=str(listing.id), tenant_id=str(listing.tenant_id))
+    result = await agent.execute(ctx)
+
+    # Synthetic service returns TARGET_COMP_COUNT (6) comps
+    assert result["comparables_count"] == 6
+    mock_storage.upload.assert_called_once()

--- a/tests/test_api/test_cma_gate.py
+++ b/tests/test_api/test_cma_gate.py
@@ -1,0 +1,88 @@
+"""Superadmin gate on CMA endpoints.
+
+The CMA feature currently runs on the synthetic-comparables fallback path
+because Repliers ($200/mo minimum) isn't activated yet. Until it is, the
+endpoints are superadmin-only so staff can demo/QA without exposing
+unverified comps to paying tenants.
+"""
+import uuid
+
+import jwt as pyjwt
+import pytest
+from httpx import AsyncClient
+
+from listingjet.config import settings
+from tests.conftest import promote_to_superadmin
+
+
+async def _register(client: AsyncClient) -> tuple[str, str]:
+    """Register a fresh user and return (token, tenant_id). Still regular role."""
+    email = f"cma-{uuid.uuid4()}@example.com"
+    resp = await client.post("/auth/register", json={
+        "email": email,
+        "password": "CmaPass1!",
+        "name": "CMA User",
+        "company_name": "CmaCo",
+        "plan_tier": "free",
+    })
+    assert resp.status_code == 200, resp.text
+    token = resp.json()["access_token"]
+    payload = pyjwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
+    return token, payload["tenant_id"]
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_generate_cma_report_requires_superadmin(async_client: AsyncClient):
+    """Regular tenant admins (the default registered role) get 403."""
+    token, _tenant_id = await _register(async_client)
+    listing_id = uuid.uuid4()
+
+    resp = await async_client.post(
+        f"/listings/{listing_id}/cma-report",
+        headers=_auth(token),
+    )
+    assert resp.status_code == 403
+    assert "admin" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_get_cma_report_requires_superadmin(async_client: AsyncClient):
+    """Non-superadmins can't read CMA reports either."""
+    token, _tenant_id = await _register(async_client)
+    listing_id = uuid.uuid4()
+
+    resp = await async_client.get(
+        f"/listings/{listing_id}/cma-report",
+        headers=_auth(token),
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_cma_endpoints_reject_unauthenticated(async_client: AsyncClient):
+    listing_id = uuid.uuid4()
+    post_resp = await async_client.post(f"/listings/{listing_id}/cma-report")
+    get_resp = await async_client.get(f"/listings/{listing_id}/cma-report")
+    assert post_resp.status_code in (401, 403)
+    assert get_resp.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_superadmin_gets_past_gate_on_get(async_client: AsyncClient):
+    """Superadmin role passes the auth gate. No report exists yet → 404 (not 403)."""
+    token, _tenant_id = await _register(async_client)
+    await promote_to_superadmin(async_client, token)
+    listing_id = uuid.uuid4()
+
+    resp = await async_client.get(
+        f"/listings/{listing_id}/cma-report",
+        headers=_auth(token),
+    )
+    # The key assertion: NOT 403. A 404 means the gate let us through and
+    # we hit the "no report found" branch, which is the expected path for a
+    # fresh listing_id with no CMA generated yet.
+    assert resp.status_code == 404

--- a/tests/test_providers/test_repliers.py
+++ b/tests/test_providers/test_repliers.py
@@ -1,0 +1,195 @@
+"""Tests for the Repliers provider (HTTP client + normalizer)."""
+import pytest
+from pytest_httpx import HTTPXMock
+
+from listingjet.providers.repliers import RepliersClient, normalize_listing
+
+BASE_URL = "https://api.repliers.io"
+
+
+def _sample_listing(**overrides) -> dict:
+    """A realistic Repliers listing record, overridable per-test."""
+    base = {
+        "mlsNumber": "C1234567",
+        "listPrice": 850_000,
+        "soldPrice": 835_000,
+        "soldDate": "2024-11-04",
+        "status": "Sld",
+        "address": {
+            "streetNumber": "123",
+            "streetName": "Oak",
+            "streetSuffix": "Ave",
+            "city": "Austin",
+            "state": "TX",
+            "zip": "78701",
+        },
+        "details": {
+            "numBedrooms": 3,
+            "numBathrooms": 2,
+            "sqft": 1800,
+            "yearBuilt": 2010,
+            "propertyType": "Residential",
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+# ----------------------------------------------------------------------
+# RepliersClient — configuration guardrails
+# ----------------------------------------------------------------------
+
+def test_client_not_configured_when_no_key():
+    client = RepliersClient(api_key="", base_url=BASE_URL)
+    assert client.configured is False
+
+
+def test_client_configured_with_key():
+    client = RepliersClient(api_key="test-key", base_url=BASE_URL)
+    assert client.configured is True
+
+
+@pytest.mark.asyncio
+async def test_search_listings_returns_empty_when_no_key():
+    """Unconfigured client never makes an HTTP request."""
+    client = RepliersClient(api_key="", base_url=BASE_URL)
+    # pytest-httpx with no add_response would raise on any real request
+    result = await client.search_listings({"city": "Austin"})
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_similar_returns_empty_when_no_key():
+    client = RepliersClient(api_key="", base_url=BASE_URL)
+    result = await client.get_similar("C1234567")
+    assert result == []
+
+
+# ----------------------------------------------------------------------
+# RepliersClient — HTTP happy paths
+# ----------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_search_listings_returns_listings_list(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        url=f"{BASE_URL}/listings?city=Austin&pageSize=10",
+        json={"listings": [_sample_listing(), _sample_listing(mlsNumber="C7654321")]},
+    )
+    client = RepliersClient(api_key="test-key", base_url=BASE_URL)
+    result = await client.search_listings({"city": "Austin", "pageSize": 10})
+    assert len(result) == 2
+    assert result[0]["mlsNumber"] == "C1234567"
+
+
+@pytest.mark.asyncio
+async def test_search_listings_sends_api_key_header(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(json={"listings": []})
+    client = RepliersClient(api_key="secret-key-123", base_url=BASE_URL)
+    await client.search_listings({"city": "Austin"})
+    request = httpx_mock.get_request()
+    assert request is not None
+    assert request.headers.get("REPLIERS-API-KEY") == "secret-key-123"
+
+
+@pytest.mark.asyncio
+async def test_search_listings_handles_missing_listings_key(httpx_mock: HTTPXMock):
+    """Server returns 200 with unexpected shape — we return empty list, not crash."""
+    httpx_mock.add_response(json={"unexpected": "shape"})
+    client = RepliersClient(api_key="test-key", base_url=BASE_URL)
+    result = await client.search_listings({"city": "Austin"})
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_search_listings_swallows_http_error(httpx_mock: HTTPXMock):
+    """A 500 from Repliers should not blow up the caller — return empty list."""
+    httpx_mock.add_response(status_code=500, text="server error")
+    client = RepliersClient(api_key="test-key", base_url=BASE_URL)
+    result = await client.search_listings({"city": "Austin"})
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_similar_hits_correct_url(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        url=f"{BASE_URL}/listings/C1234567/similar?pageSize=5",
+        json={"listings": [_sample_listing()]},
+    )
+    client = RepliersClient(api_key="test-key", base_url=BASE_URL)
+    result = await client.get_similar("C1234567", limit=5)
+    assert len(result) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_similar_swallows_network_error(httpx_mock: HTTPXMock):
+    httpx_mock.add_exception(Exception("boom"))
+    client = RepliersClient(api_key="test-key", base_url=BASE_URL)
+    result = await client.get_similar("C1234567")
+    assert result == []
+
+
+# ----------------------------------------------------------------------
+# normalize_listing — pure function, easy to exhaust
+# ----------------------------------------------------------------------
+
+def test_normalize_listing_happy_path():
+    result = normalize_listing(_sample_listing())
+    assert result == {
+        "address": "123 Oak Ave, Austin",
+        "beds": 3,
+        "baths": 2.0,
+        "sqft": 1800,
+        "price": 835_000,  # soldPrice preferred over listPrice
+        "price_per_sqft": 463.89,
+        "sold_date": "2024-11-04",
+        "mls_number": "C1234567",
+    }
+
+
+def test_normalize_listing_falls_back_to_list_price():
+    """When soldPrice is missing, use listPrice."""
+    raw = _sample_listing()
+    raw.pop("soldPrice")
+    result = normalize_listing(raw)
+    assert result is not None
+    assert result["price"] == 850_000
+
+
+def test_normalize_listing_returns_none_when_no_price():
+    raw = _sample_listing()
+    raw.pop("soldPrice")
+    raw.pop("listPrice")
+    assert normalize_listing(raw) is None
+
+
+def test_normalize_listing_returns_none_when_no_sqft():
+    raw = _sample_listing()
+    raw["details"] = {"numBedrooms": 3, "numBathrooms": 2}
+    assert normalize_listing(raw) is None
+
+
+def test_normalize_listing_handles_zero_sqft():
+    raw = _sample_listing()
+    raw["details"]["sqft"] = 0
+    assert normalize_listing(raw) is None
+
+
+def test_normalize_listing_handles_missing_address_parts():
+    raw = _sample_listing()
+    raw["address"] = {"streetName": "Oak", "city": "Austin"}
+    result = normalize_listing(raw)
+    assert result is not None
+    assert result["address"] == "Oak, Austin"
+
+
+def test_normalize_listing_handles_nulls_in_address_parts():
+    raw = _sample_listing()
+    raw["address"] = {
+        "streetNumber": None,
+        "streetName": "Oak",
+        "streetSuffix": None,
+        "city": "Austin",
+    }
+    result = normalize_listing(raw)
+    assert result is not None
+    assert result["address"] == "Oak, Austin"

--- a/tests/test_services/test_comparables.py
+++ b/tests/test_services/test_comparables.py
@@ -1,0 +1,240 @@
+"""Tests for ComparablesService — Repliers-first with synthetic fallback."""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from listingjet.providers.repliers import RepliersClient
+from listingjet.services.comparables import (
+    TARGET_COMP_COUNT,
+    ComparablesService,
+    _build_filters,
+    _extract_city,
+    _extract_state,
+)
+
+
+def _subject(**overrides) -> dict:
+    base = {
+        "address": "123 Main St, Austin, TX",
+        "beds": 3,
+        "baths": 2,
+        "sqft": 1800,
+        "year_built": 2010,
+        "property_type": "single_family",
+        "price": 450_000,
+    }
+    base.update(overrides)
+    return base
+
+
+def _raw_repliers_listing(price=425_000, sqft=1750, mls="C1234567") -> dict:
+    return {
+        "mlsNumber": mls,
+        "soldPrice": price,
+        "soldDate": "2024-11-04",
+        "status": "Sld",
+        "address": {
+            "streetNumber": "456",
+            "streetName": "Pine",
+            "streetSuffix": "St",
+            "city": "Austin",
+            "state": "TX",
+        },
+        "details": {
+            "numBedrooms": 3,
+            "numBathrooms": 2,
+            "sqft": sqft,
+        },
+    }
+
+
+# ----------------------------------------------------------------------
+# Pure helpers
+# ----------------------------------------------------------------------
+
+def test_extract_city_from_comma_string():
+    assert _extract_city({"address": "123 Main St, Austin, TX"}) == "Austin"
+
+
+def test_extract_city_from_dict():
+    assert _extract_city({"address": {"city": "Austin", "state": "TX"}}) == "Austin"
+
+
+def test_extract_city_empty_for_unparseable():
+    assert _extract_city({"address": "not an address"}) == ""
+    assert _extract_city({}) == ""
+
+
+def test_extract_state_from_comma_string():
+    assert _extract_state({"address": "123 Main St, Austin, TX"}) == "TX"
+
+
+def test_extract_state_from_comma_string_with_zip():
+    assert _extract_state({"address": "123 Main St, Austin, TX 78701"}) == "TX"
+
+
+def test_build_filters_full_subject():
+    filters = _build_filters(_subject())
+    assert filters is not None
+    assert filters["status"] == "Sld"
+    assert filters["city"] == "Austin"
+    assert filters["state"] == "TX"
+    assert filters["minBedrooms"] == 2
+    assert filters["maxBedrooms"] == 4
+    assert 1400 <= filters["minSqft"] <= 1500  # ~20% under 1800
+    assert 2100 <= filters["maxSqft"] <= 2200  # ~20% over 1800
+
+
+def test_build_filters_returns_none_without_city():
+    assert _build_filters({"beds": 3, "sqft": 1800}) is None
+
+
+def test_build_filters_handles_missing_optional_fields():
+    filters = _build_filters({"address": "X, Austin, TX"})
+    assert filters is not None
+    assert filters["city"] == "Austin"
+    assert "minBedrooms" not in filters
+    assert "minSqft" not in filters
+
+
+# ----------------------------------------------------------------------
+# ComparablesService.fetch() — feature-flag paths
+# ----------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_fetch_uses_synthetic_when_flag_off():
+    """repliers_cma_enabled=False → never calls Repliers, returns synthetic."""
+    mock_client = RepliersClient(api_key="key", base_url="https://fake")
+    mock_client.search_listings = AsyncMock(return_value=[])
+    service = ComparablesService(repliers_client=mock_client)
+
+    with patch("listingjet.services.comparables.settings.repliers_cma_enabled", False):
+        result = await service.fetch(_subject())
+
+    assert len(result) == TARGET_COMP_COUNT
+    mock_client.search_listings.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fetch_uses_synthetic_when_key_missing():
+    """repliers_cma_enabled=True but no key → synthetic fallback."""
+    mock_client = RepliersClient(api_key="", base_url="https://fake")
+    mock_client.search_listings = AsyncMock(return_value=[])
+    service = ComparablesService(repliers_client=mock_client)
+
+    with patch("listingjet.services.comparables.settings.repliers_cma_enabled", True):
+        result = await service.fetch(_subject())
+
+    assert len(result) == TARGET_COMP_COUNT
+    mock_client.search_listings.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fetch_returns_repliers_comps_when_enabled_and_configured():
+    mock_client = RepliersClient(api_key="key", base_url="https://fake")
+    mock_client.search_listings = AsyncMock(return_value=[
+        _raw_repliers_listing(price=425_000, sqft=1750, mls="A1"),
+        _raw_repliers_listing(price=440_000, sqft=1850, mls="A2"),
+        _raw_repliers_listing(price=410_000, sqft=1700, mls="A3"),
+    ])
+    service = ComparablesService(repliers_client=mock_client)
+
+    with patch("listingjet.services.comparables.settings.repliers_cma_enabled", True):
+        result = await service.fetch(_subject())
+
+    assert len(result) == 3
+    assert result[0]["mls_number"] == "A1"
+    assert result[0]["price"] == 425_000
+    assert result[0]["sqft"] == 1750
+    mock_client.search_listings.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_falls_back_to_synthetic_on_empty_repliers():
+    """Repliers returns [] → we fall back rather than return an empty CMA."""
+    mock_client = RepliersClient(api_key="key", base_url="https://fake")
+    mock_client.search_listings = AsyncMock(return_value=[])
+    service = ComparablesService(repliers_client=mock_client)
+
+    with patch("listingjet.services.comparables.settings.repliers_cma_enabled", True):
+        result = await service.fetch(_subject())
+
+    assert len(result) == TARGET_COMP_COUNT
+    mock_client.search_listings.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_falls_back_to_synthetic_on_repliers_exception():
+    """Repliers raises → fallback, no exception bubbles up."""
+    mock_client = RepliersClient(api_key="key", base_url="https://fake")
+    mock_client.search_listings = AsyncMock(side_effect=RuntimeError("boom"))
+    service = ComparablesService(repliers_client=mock_client)
+
+    with patch("listingjet.services.comparables.settings.repliers_cma_enabled", True):
+        result = await service.fetch(_subject())
+
+    assert len(result) == TARGET_COMP_COUNT
+
+
+@pytest.mark.asyncio
+async def test_fetch_caps_repliers_results_at_target_count():
+    """Even if Repliers returns 20 results, we only keep TARGET_COMP_COUNT."""
+    mock_client = RepliersClient(api_key="key", base_url="https://fake")
+    mock_client.search_listings = AsyncMock(return_value=[
+        _raw_repliers_listing(mls=f"X{i}") for i in range(20)
+    ])
+    service = ComparablesService(repliers_client=mock_client)
+
+    with patch("listingjet.services.comparables.settings.repliers_cma_enabled", True):
+        result = await service.fetch(_subject())
+
+    assert len(result) == TARGET_COMP_COUNT
+
+
+@pytest.mark.asyncio
+async def test_fetch_skips_unnormalizable_listings():
+    """Listings missing essential fields are dropped during normalization."""
+    mock_client = RepliersClient(api_key="key", base_url="https://fake")
+    mock_client.search_listings = AsyncMock(return_value=[
+        _raw_repliers_listing(mls="GOOD"),
+        {"mlsNumber": "BAD", "address": {}},  # no price, no sqft
+        _raw_repliers_listing(mls="GOOD2"),
+    ])
+    service = ComparablesService(repliers_client=mock_client)
+
+    with patch("listingjet.services.comparables.settings.repliers_cma_enabled", True):
+        result = await service.fetch(_subject())
+
+    assert len(result) == 2
+    assert {c["mls_number"] for c in result} == {"GOOD", "GOOD2"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_skips_repliers_when_city_unknown():
+    """No city in subject → skip Repliers entirely (can't build a useful query)."""
+    mock_client = RepliersClient(api_key="key", base_url="https://fake")
+    mock_client.search_listings = AsyncMock(return_value=[])
+    service = ComparablesService(repliers_client=mock_client)
+
+    subject = {"beds": 3, "sqft": 1800, "price": 400_000}  # no address
+
+    with patch("listingjet.services.comparables.settings.repliers_cma_enabled", True):
+        result = await service.fetch(subject)
+
+    assert len(result) == TARGET_COMP_COUNT  # synthetic fallback
+    mock_client.search_listings.assert_not_called()
+
+
+# ----------------------------------------------------------------------
+# Synthetic fallback shape (locks the contract with CMAReportAgent)
+# ----------------------------------------------------------------------
+
+def test_synthetic_comparables_shape():
+    comps = ComparablesService._synthetic_comparables(_subject())
+    assert len(comps) == TARGET_COMP_COUNT
+    for c in comps:
+        assert {"address", "beds", "baths", "sqft", "price", "price_per_sqft"} <= set(c)
+        assert isinstance(c["price"], int)
+        assert isinstance(c["sqft"], int)
+        assert c["sqft"] > 0
+        assert c["price"] > 0


### PR DESCRIPTION
CMAReportAgent previously rendered fabricated comps. This wires in a
Repliers-first ComparablesService that falls back to the old synthetic
path when Repliers is disabled, unconfigured, or returns empty — so
behavior is unchanged until REPLIERS_CMA_ENABLED is flipped on.

- providers/repliers.py: async httpx client + listing normalizer
- services/comparables.py: Repliers-first lookup with synthetic fallback
- agents/cma_report.py: inject ComparablesService, drop inline generator
- config: repliers_api_key, repliers_api_base, repliers_cma_enabled,
  repliers_timeout_seconds (ships dark by default)
- 34 new unit tests (17 provider + 17 service), all green