### PR TITLE
fix(vercel): use https for api rewrite destination

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -7,7 +7,7 @@
   "rewrites": [
     {
       "source": "/api/:path*",
-      "destination": "http://api.listingjet.ai/:path*"
+      "destination": "https://api.listingjet.ai/:path*"
     }
   ],
   "env": {

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
   "rewrites": [
     {
       "source": "/api/:path*",
-      "destination": "http://Listin-ApiSe-Ly4m06X1ArNQ-22089779.us-east-1.elb.amazonaws.com/:path*"
+      "destination": "https://api.listingjet.ai/:path*"
     }
   ],
   "env": {


### PR DESCRIPTION
## Summary
- Production sign-in and analytics are broken on listingjet.ai with CORS errors: `Access to fetch at 'https://api.listingjet.ai/auth/login' (redirected from 'https://listingjet.ai/api/auth/login') ... No 'Access-Control-Allow-Origin' header`.
- Root cause: `frontend/vercel.json` (and root `vercel.json`) had rewrite destinations using `http://`. Cloudflare 301-redirects HTTP → HTTPS, Vercel proxies that 301 back to the browser, the browser follows cross-origin, and CORS blocks it.
- Fix: switch both rewrites to `https://api.listingjet.ai/:path*` so Vercel gets a real 200 and proxies it transparently (same-origin from the browser's perspective).

Verified with `curl -sI https://listingjet.ai/api/auth/login` pre-fix: returned `301` with `location: https://api.listingjet.ai/auth/login` and `x-vercel-id` confirming Vercel was the one serving the redirect.

## Test plan
- [ ] After deploy, `curl -sI -X POST https://listingjet.ai/api/auth/login` should NOT return 301 — expect 405/422/401 from the backend, proxied through.
- [ ] Sign in from https://listingjet.ai/login — no CORS errors in console.
- [ ] `/analytics/events` request fires without CORS error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)