### PR TITLE
fix(billing): portal works w/o checkout + public launch endpoints

### DIFF
--- a/frontend/src/app/billing/page.tsx
+++ b/frontend/src/app/billing/page.tsx
@@ -369,7 +369,10 @@ function BillingContent() {
                   const { portal_url } = await apiClient.billingPortal(window.location.href);
                   window.location.href = portal_url;
                 } catch (err: unknown) {
-                  alert(err instanceof Error ? err.message : "Failed to open billing portal");
+                  toast(
+                    err instanceof Error ? err.message : "Failed to open billing portal",
+                    "error",
+                  );
                 }
               }}
               className="px-6 py-3 rounded-full border border-[var(--color-border)] text-sm font-semibold text-[var(--color-text-secondary)] hover:border-amber-400 hover:text-amber-600 hover:shadow-lg hover:shadow-amber-500/10 hover:-translate-y-0.5 active:translate-y-0 transition-all duration-200"

--- a/src/listingjet/api/billing.py
+++ b/src/listingjet/api/billing.py
@@ -115,10 +115,23 @@ async def create_portal(
     tenant = await db.get(Tenant, current_user.tenant_id)
     if not tenant:
         raise HTTPException(status_code=404, detail="Tenant not found")
-    if not tenant.stripe_customer_id:
-        raise HTTPException(status_code=400, detail="No billing account — complete checkout first")
 
     svc = BillingService()
+
+    # Create the Stripe customer on-demand so users who have not yet purchased
+    # a subscription can still manage payment methods + see invoices.
+    if not tenant.stripe_customer_id:
+        try:
+            tenant.stripe_customer_id = svc.create_customer(
+                email=current_user.email,
+                name=tenant.name,
+                tenant_id=str(tenant.id),
+            )
+            await db.commit()
+        except stripe_mod.StripeError as e:
+            logger.error("stripe_customer_create_error type=%s message=%s", type(e).__name__, str(e))
+            raise HTTPException(status_code=502, detail="Billing portal temporarily unavailable")
+
     try:
         url = svc.create_portal_session(
             customer_id=tenant.stripe_customer_id,

--- a/src/listingjet/middleware/tenant.py
+++ b/src/listingjet/middleware/tenant.py
@@ -5,7 +5,7 @@ from starlette.responses import JSONResponse
 
 from listingjet.config import settings
 
-_PUBLIC_PATHS = {"/health", "/health/deep", "/auth/register", "/auth/login", "/auth/refresh", "/auth/forgot-password", "/auth/reset-password", "/auth/accept-invite", "/billing/webhook", "/demo/upload", "/addons", "/branding"}
+_PUBLIC_PATHS = {"/health", "/health/deep", "/auth/register", "/auth/login", "/auth/refresh", "/auth/forgot-password", "/auth/reset-password", "/auth/accept-invite", "/billing/webhook", "/demo/upload", "/addons", "/branding", "/founding/remaining", "/analytics/events"}
 
 # Prefix matches for routes with a path parameter that must be public
 # (e.g. GET /auth/invite/{token}, the public invite lookup).


### PR DESCRIPTION
## Summary
Three small fixes bundled:

1. **`/billing/portal` 400 dead-end** — The endpoint required a pre-existing `stripe_customer_id` and returned 400 otherwise, so users on the free plan clicking "Manage Subscription" got stuck. It now creates the Stripe customer on-demand (same pattern as `/checkout`) so the portal always opens. Users can then manage payment methods and view invoices even before subscribing.
2. **`/founding/remaining` + `/analytics/events` 401** — Both are public by design (landing-page counter, unauthenticated analytics ingest) but the tenant middleware allowlist didn't include them. Added to `_PUBLIC_PATHS`.
3. **Billing page `alert()`** — Replaced with the existing `toast` so failures surface consistently with the rest of the app.

## Test plan
- [ ] Log in with a fresh free-plan tenant (no `stripe_customer_id`), click "Manage Subscription" on `/billing` → redirected to Stripe's portal, no 400.
- [ ] Confirm `tenants.stripe_customer_id` is populated after that click.
- [ ] `curl -s https://listingjet.ai/api/founding/remaining` returns JSON (no 401).
- [ ] `curl -s -X POST https://listingjet.ai/api/analytics/events -H 'Content-Type: application/json' -d '{"event":"test"}'` returns 204 (no 401).
- [ ] Trigger a portal failure (e.g. bad `return_url`) → toast appears, no browser alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)