### PR TITLE
fix(billing): always allow canonical listingjet domains as redirect URLs

### DIFF
--- a/src/listingjet/api/billing.py
+++ b/src/listingjet/api/billing.py
@@ -32,14 +32,19 @@ router = APIRouter()
 
 
 def _validate_redirect_url(url: str) -> None:
-    """Reject redirect URLs that don't match a configured CORS origin or Vercel pattern."""
+    """Reject redirect URLs that don't match a configured CORS origin, the
+    canonical production domains, or the preview Vercel pattern."""
     import re
     allowed = {o.strip().rstrip("/") for o in settings.cors_origins.split(",")}
     parsed = urlparse(url)
     origin = f"{parsed.scheme}://{parsed.netloc}".rstrip("/")
     if origin in allowed:
         return
-    # Also allow the same Vercel pattern used in CORS middleware
+    # Always allow the canonical production domains so env var drift in
+    # cors_origins can never break checkout/portal redirects in prod.
+    if re.fullmatch(r"https://(www\.)?listingjet\.(ai|com)", origin):
+        return
+    # Allow preview deployments on the Vercel pattern used in CORS middleware.
     if re.fullmatch(r"https://listingjet[a-z0-9-]*\.vercel\.app", origin):
         return
     raise HTTPException(status_code=400, detail="Redirect URL not allowed")


### PR DESCRIPTION
## Summary
Production `/api/billing/portal` and `/api/billing/checkout` are returning 400 "Redirect URL not allowed" because the ECS task's \`cors_origins\` env var does not include \`https://listingjet.ai\`, and the redirect URL validator was only permitting origins from that env var or the Vercel preview pattern.

This hard-codes a regex for the canonical production domains (\`listingjet.ai\` / \`listingjet.com\`, with or without \`www\`) so checkout and portal redirects succeed regardless of env var drift. The existing env-driven and Vercel-preview allowances are untouched.

This change was intended to land in #215 but did not make it into that merge.

## Test plan
- [ ] After deploy, clicking "Manage Subscription" on /billing on the prod site redirects to Stripe's portal (no 400).
- [ ] Clicking a plan on /pricing redirects to Stripe Checkout (no 400).
- [ ] Requests with \`return_url=https://evil.com/...\` still 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)