### PR TITLE
feat(auth): auto-refresh access token

### DIFF
--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -6,10 +6,25 @@ import {
   useState,
   useEffect,
   useCallback,
+  useRef,
   type ReactNode,
 } from "react";
 import apiClient from "@/lib/api-client";
 import type { UserResponse } from "@/lib/types";
+
+const REFRESH_TOKEN_KEY = "listingjet_refresh_token";
+// Access tokens expire after 15 minutes; refresh every 12 to stay ahead.
+const REFRESH_INTERVAL_MS = 12 * 60 * 1000;
+
+function storeTokens(accessToken: string | undefined | null, refreshToken: string | undefined | null) {
+  if (accessToken) {
+    localStorage.setItem("listingjet_token", accessToken);
+    apiClient.setToken(accessToken);
+  }
+  if (refreshToken) {
+    localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+  }
+}
 
 interface AuthContextValue {
   user: UserResponse | null;
@@ -26,37 +41,98 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<UserResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  const refreshingRef = useRef<Promise<string | null> | null>(null);
+
+  const tryRefresh = useCallback(async (): Promise<string | null> => {
+    // Coalesce concurrent refresh attempts so we only hit /auth/refresh once.
+    if (refreshingRef.current) return refreshingRef.current;
+    const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY);
+    if (!refreshToken) return null;
+    const p = apiClient.refreshAccessToken(refreshToken).finally(() => {
+      refreshingRef.current = null;
+    });
+    refreshingRef.current = p;
+    const newToken = await p;
+    if (newToken) {
+      localStorage.setItem("listingjet_token", newToken);
+    }
+    return newToken;
+  }, []);
+
+  const clearSession = useCallback(() => {
+    localStorage.removeItem("listingjet_logged_in");
+    localStorage.removeItem("listingjet_token");
+    localStorage.removeItem(REFRESH_TOKEN_KEY);
+    apiClient.setToken(null);
+    setUser(null);
+  }, []);
 
   useEffect(() => {
-    // Only attempt /auth/me if we have a saved token. This avoids a noisy
-    // 401 console error on every unauthenticated page load.
+    let cancelled = false;
     const savedToken = localStorage.getItem("listingjet_token");
-    if (!savedToken) {
+    const savedRefresh = localStorage.getItem(REFRESH_TOKEN_KEY);
+    if (!savedToken && !savedRefresh) {
       setLoading(false);
       return;
     }
-    apiClient.setToken(savedToken);
-    apiClient
-      .me()
-      .then((u) => {
+    if (savedToken) apiClient.setToken(savedToken);
+
+    (async () => {
+      try {
+        const u = await apiClient.me();
+        if (cancelled) return;
         setUser(u);
         localStorage.setItem("listingjet_logged_in", "1");
-      })
-      .catch(() => {
-        localStorage.removeItem("listingjet_logged_in");
-        localStorage.removeItem("listingjet_token");
-        apiClient.setToken(null);
-      })
-      .finally(() => setLoading(false));
-  }, []);
+      } catch (err) {
+        // Access token likely expired — try to refresh once.
+        const status = (err as { status?: number })?.status;
+        if (status === 401 && savedRefresh) {
+          const newToken = await tryRefresh();
+          if (newToken) {
+            try {
+              const u = await apiClient.me();
+              if (cancelled) return;
+              setUser(u);
+              localStorage.setItem("listingjet_logged_in", "1");
+              return;
+            } catch {
+              // fall through to logout
+            }
+          }
+        }
+        if (!cancelled) clearSession();
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tryRefresh, clearSession]);
+
+  // Keep the access token fresh while the user is signed in: periodic refresh
+  // for long sessions, plus a refresh on tab becoming visible again.
+  useEffect(() => {
+    if (!user) return;
+    const interval = window.setInterval(() => {
+      void tryRefresh();
+    }, REFRESH_INTERVAL_MS);
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") {
+        void tryRefresh();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [user, tryRefresh]);
 
   const login = useCallback(async (email: string, password: string) => {
     const res = await apiClient.login(email, password);
-    // Store token for Bearer auth (works cross-origin); cookies are backup (same-origin)
-    if (res.access_token) {
-      localStorage.setItem("listingjet_token", res.access_token);
-      apiClient.setToken(res.access_token);
-    }
+    storeTokens(res.access_token, res.refresh_token);
     const me = await apiClient.me();
     setUser(me);
     localStorage.setItem("listingjet_logged_in", "1");
@@ -64,10 +140,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const loginWithGoogle = useCallback(async (idToken: string) => {
     const res = await apiClient.googleLogin(idToken);
-    if (res.access_token) {
-      localStorage.setItem("listingjet_token", res.access_token);
-      apiClient.setToken(res.access_token);
-    }
+    storeTokens(res.access_token, res.refresh_token);
     const me = await apiClient.me();
     setUser(me);
     localStorage.setItem("listingjet_logged_in", "1");
@@ -76,10 +149,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const register = useCallback(
     async (email: string, password: string, name: string, companyName: string, planTier?: string, consent?: boolean, aiConsent?: boolean) => {
       const res = await apiClient.register(email, password, name, companyName, planTier, consent ?? true, aiConsent ?? true);
-      if (res.access_token) {
-        localStorage.setItem("listingjet_token", res.access_token);
-        apiClient.setToken(res.access_token);
-      }
+      storeTokens(res.access_token, res.refresh_token);
       const me = await apiClient.me();
       setUser(me);
       localStorage.setItem("listingjet_logged_in", "1");
@@ -90,10 +160,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const acceptInvite = useCallback(
     async (token: string, password: string, name?: string) => {
       const res = await apiClient.acceptInvite({ token, password, name });
-      if (res.access_token) {
-        localStorage.setItem("listingjet_token", res.access_token);
-        apiClient.setToken(res.access_token);
-      }
+      storeTokens(res.access_token, res.refresh_token);
       const me = await apiClient.me();
       setUser(me);
       localStorage.setItem("listingjet_logged_in", "1");
@@ -110,11 +177,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     } catch {
       // Best-effort
     }
-    localStorage.removeItem("listingjet_logged_in");
-    localStorage.removeItem("listingjet_token");
-    apiClient.setToken(null);
-    setUser(null);
-  }, []);
+    clearSession();
+  }, [clearSession]);
 
   return (
     <AuthContext.Provider value={{ user, loading, login, loginWithGoogle, register, acceptInvite, logout }}>

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -220,6 +220,24 @@ class ApiClient {
     return data as UserResponse;
   }
 
+  /** Exchange a refresh token for a new access token. Returns the new
+   *  access_token on success, or null on failure (caller should log out). */
+  async refreshAccessToken(refreshToken: string): Promise<string | null> {
+    try {
+      const res = await this.request<TokenResponse>("/auth/refresh", {
+        method: "POST",
+        body: JSON.stringify({ refresh_token: refreshToken }),
+      });
+      if (res?.access_token) {
+        this.setToken(res.access_token);
+        return res.access_token;
+      }
+    } catch {
+      // fall through
+    }
+    return null;
+  }
+
   async googleLogin(idToken: string): Promise<TokenResponse> {
     return this.request<TokenResponse>("/auth/google", {
       method: "POST",

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -5,6 +5,7 @@
 export interface TokenResponse {
   access_token: string;
   token_type: string;
+  refresh_token?: string;
 }
 
 export interface UserResponse {


### PR DESCRIPTION
## Summary
Access tokens expire after 15 minutes (\`jwt_expiry_minutes: 15\`). The frontend previously stored only the access token and logged users out on the first 401 from \`/auth/me\` — so anyone returning to a tab after 15+ minutes got silently signed out.

This PR:
- Persists the \`refresh_token\` returned by login / register / Google login / accept-invite to localStorage.
- Adds \`apiClient.refreshAccessToken\` which POSTs to \`/auth/refresh\` and updates the bearer token.
- In \`AuthProvider\`:
  - On mount, if the access token is present but \`/auth/me\` returns 401, try a refresh once before clearing the session.
  - While signed in, refresh every 12 minutes AND when the tab becomes visible. Concurrent refreshes are coalesced via a ref.
- Extends the \`TokenResponse\` type with optional \`refresh_token\`.

This doesn't touch the backend — \`/auth/refresh\` and the refresh-token issuance both already exist.

## Test plan
- [ ] Log in, inspect localStorage → \`listingjet_refresh_token\` is set.
- [ ] Hard-refresh the page — still logged in, no 401 in console.
- [ ] Leave tab inactive for ~20 minutes, return → tab becoming visible triggers a refresh; authenticated requests (e.g. /analytics) succeed without re-login.
- [ ] Log out → all three localStorage keys (\`listingjet_token\`, \`listingjet_refresh_token\`, \`listingjet_logged_in\`) are cleared.
- [ ] With refresh token revoked on backend, refresh fails silently and the user is cleanly logged out instead of left in a broken state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)