### PR TITLE
fix(pricing): surface checkout errors + handle Team tier without price

### DIFF
--- a/frontend/src/app/pricing/page.tsx
+++ b/frontend/src/app/pricing/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import { Nav } from "@/components/layout/nav";
 import apiClient from "@/lib/api-client";
+import { useToast } from "@/components/ui/toast";
 
 const PRICE_IDS: Record<string, string> = {
   lite: "price_1TH4J9RZ4TuRrBpyUHm6Eg5p",
@@ -114,6 +115,7 @@ export default function PricingPage() {
   const [stagingListings, setStagingListings] = useState(1);
   const [checkoutLoading, setCheckoutLoading] = useState<string | null>(null);
   const router = useRouter();
+  const { toast } = useToast();
 
   async function handleTierCheckout(tierKey: string) {
     const token = localStorage.getItem("listingjet_token");
@@ -126,7 +128,13 @@ export default function PricingPage() {
       return;
     }
     const priceId = PRICE_IDS[tierKey];
-    if (!priceId) return;
+    if (!priceId) {
+      // Tiers without a Stripe price configured (e.g. Team) route to contact sales.
+      window.location.href = `mailto:hello@listingjet.ai?subject=${encodeURIComponent(
+        `Interested in the ${tierKey} plan`,
+      )}`;
+      return;
+    }
     setCheckoutLoading(tierKey);
     try {
       const res = await apiClient.billingCheckout(
@@ -139,6 +147,7 @@ export default function PricingPage() {
       window.location.href = res.checkout_url;
     } catch (err) {
       console.error("Checkout failed:", err);
+      toast(err instanceof Error ? err.message : "Checkout failed", "error");
       setCheckoutLoading(null);
     }
   }


### PR DESCRIPTION
## Summary
On /pricing the "Team" plan button silently did nothing — it had no entry in the frontend \`PRICE_IDS\` map, so \`handleTierCheckout\` returned early. The other tiers' checkout button swallowed backend errors with a \`console.error\`, so users got no feedback when checkout 4xx'd (e.g. the current 400 "Redirect URL not allowed" on prod).

This PR:
- Sends users who pick a tier with no configured Stripe price to a \`mailto:hello@listingjet.ai\` so the click always does something.
- Replaces the silent \`console.error\` on checkout failure with a toast showing the error detail.

## Test plan
- [ ] Click the Team tier on /pricing → opens a mailto with a prefilled subject.
- [ ] Click Lite / Active Agent while the backend is returning an error → toast appears with the error message.
- [ ] Happy-path checkout still redirects to Stripe when the backend returns a valid URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)