### PR TITLE
infra(cdk): rename Redis construct id to enable type migration

### DIFF
--- a/infra/stacks/database.py
+++ b/infra/stacks/database.py
@@ -73,7 +73,7 @@ class DatabaseStack(Stack):
         )
 
         self.redis_cluster = elasticache.CfnReplicationGroup(
-            self, "Redis",
+            self, "RedisRg",
             replication_group_description="ListingJet Redis replication group",
             cache_node_type="cache.t4g.small",
             engine="redis",


### PR DESCRIPTION
## Summary
\`cdk deploy\` on \`ListingJetDatabase\` fails with \`Update of resource type is not permitted ... [Redis]\`. The deployed stack has Redis as \`AWS::ElastiCache::CacheCluster\` but the CDK code instantiates \`CfnReplicationGroup\`. CloudFormation refuses in-place type changes.

Renaming the construct id \`"Redis"\` → \`"RedisRg"\` tells CloudFormation to create a new ReplicationGroup and delete the old CacheCluster — no in-place type change.

Brief Redis downtime during switchover is acceptable (no users on prod). Data in the old cluster is discarded — Redis is used for rate-limit counters and revoked-token cache, both of which are ephemeral. The endpoint changes; the app reads \`REDIS_URL\` from Secrets Manager which will need to be updated to the new RG endpoint after the deploy completes.

## Test plan
- [x] \`cdk synth\` succeeds.
- [ ] After merge: \`cdk deploy ListingJetServices\` (which cascades through Database) completes without the type-change error.
- [ ] \`REDIS_URL\` in \`listingjet/app\` secret updated to new RG endpoint.
- [ ] Services stack clears UPDATE_ROLLBACK_COMPLETE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)