### PR TITLE
infra(cdk): fix Temporal DB env var (postgresql -> postgres12)

### DIFF
--- a/infra/stacks/services.py
+++ b/infra/stacks/services.py
@@ -315,7 +315,7 @@ class ServicesStack(Stack):
                 ),
             ),
             environment={
-                "DB": "postgresql",
+                "DB": "postgres12",
                 "DB_PORT": "5432",
                 "POSTGRES_SEEDS": db_instance.db_instance_endpoint_address,
             },


### PR DESCRIPTION
## Summary
Temporal container crashes on startup with \`Unsupported driver specified: 'DB=postgresql'\`. Temporal auto-setup accepts \`postgres12\` or \`postgres12_pgx\`, not \`postgresql\`.

The live Temporal task def (rev 4) was manually patched to \`postgres12\` at some point but the CDK source was never updated. The current Services deploy (rev 11) regenerated the task def from CDK, restoring the broken value — 10+ failed task launches and blocking \`ListingJetServices\` CFN stack from completing.

Fix: change one string in \`services.py\`. Matches the known-good live rev 4 value.

## Test plan
- [x] \`cdk synth\` clean.
- [ ] After merge + redeploy: Temporal tasks launch and stay RUNNING.
- [ ] Services CFN stack reaches UPDATE_COMPLETE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)