### PR TITLE
infra(cdk): replace Worker HTTP health check with heartbeat-file check

### DIFF
--- a/infra/stacks/services.py
+++ b/infra/stacks/services.py
@@ -274,12 +274,19 @@ class ServicesStack(Stack):
                 "SMTP_PASSWORD": ecs.Secret.from_secrets_manager(app_secrets, "SMTP_PASSWORD"),
             },
             command=["worker"],
+            # The worker doesn't serve HTTP — it touches /tmp/worker-heartbeat
+            # every 15s (src/listingjet/workflows/worker.py). A hung worker
+            # stops touching it; this check fails after ~2 min of no updates.
             health_check=ecs.HealthCheck(
-                command=["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8081/health')\" || exit 1"],
+                command=[
+                    "CMD-SHELL",
+                    "find /tmp/worker-heartbeat -mmin -2 | grep -q . || exit 1",
+                ],
                 interval=Duration.seconds(30),
                 timeout=Duration.seconds(5),
                 retries=3,
-                start_period=Duration.seconds(30),
+                # Worker needs time to connect to Temporal + write first heartbeat.
+                start_period=Duration.seconds(60),
             ),
         )
 


### PR DESCRIPTION
## Summary
Worker's CDK health check probes \`http://localhost:8081/health\`, but the worker is a Temporal poller — it doesn't serve HTTP. Every rev-11 Worker task is being killed by ECS for \`Task failed container health checks\`.

The worker code was updated to use a touch-file heartbeat (\`/tmp/worker-heartbeat\`, every 15s) during the CRITICAL-7 audit fix — see \`src/listingjet/workflows/worker.py:19-22\` and \`:131-132\`. The CDK health check was never updated to match. Drift scan missed it because both sides had "some" \`healthCheck\` structure.

**Fix:** match the intended design:
\`\`\`python
command=["CMD-SHELL", "find /tmp/worker-heartbeat -mmin -2 | grep -q . || exit 1"]
\`\`\`

- \`find … -mmin -2\` emits the file path if modified in last 2 min
- \`grep -q .\` exits 1 if the file is missing or stale
- \`start_period=60s\` gives the worker time to connect to Temporal and write the first heartbeat
- \`retries=3\`, \`interval=30s\` → ~90s total failure window, well within the 120s staleness threshold

**Why keep a check instead of removing it:** a hung worker (deadlock, broken reconnect, stuck blocking call) would still have PID 1 alive — ECS would think it's healthy forever while queues back up. The heartbeat-file check catches hangs.

## Test plan
- [ ] After merge + redeploy, Worker task stays RUNNING past the 60-second start period.
- [ ] \`cdk deploy ListingJetServices\` completes cleanly.
- [ ] If heartbeat file isn't being written (worker code actually broken), check fails within 2 min — tells us fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)