### PR TITLE
infra(cdk): match live Postgres storage_encrypted=False to avoid replacement

### DIFF
--- a/infra/stacks/database.py
+++ b/infra/stacks/database.py
@@ -51,7 +51,10 @@ class DatabaseStack(Stack):
             credentials=rds.Credentials.from_generated_secret("listingjet"),
             allocated_storage=20,
             max_allocated_storage=50,
-            storage_encrypted=True,
+            # Matches live kjyxgeldpfef (unencrypted). Pre-launch only — must
+            # migrate to an encrypted instance before onboarding real users.
+            # See docs/PRE_LAUNCH_INFRA_CHECKLIST.md for the cutover plan.
+            storage_encrypted=False,
             multi_az=True,
             backup_retention=Duration.days(7),
             deletion_protection=True,


### PR DESCRIPTION
## Summary
Every recent \`cdk deploy ListingJetDatabase\` has tried to REPLACE the Postgres instance because CDK had \`storage_encrypted=True\` but the live instance was created without encryption. AWS cannot toggle RDS encryption in place; the only migration path is snapshot + restore.

The Redis rename (#228) tripped this on its most recent deploy: CFN created a new (encrypted) instance \`lfk5bsiimapu\`, then tried to delete the original \`kjyxgeldpfef\` which is protected. Stack rolled back; deletion protection saved us.

Full drift analysis (live vs CDK synth on Postgres):

| Property | Live | CDK | Effect |
|---|---|---|---|
| BackupRetentionPeriod | 1 | 7 | in-place |
| DBInstanceClass | db.t4g.micro | db.t4g.small | in-place |
| DeletionProtection | false | true | in-place |
| MultiAZ | false | true | in-place |
| **StorageEncrypted** | **missing** | **true** | **forces replacement** |

This PR changes only \`storage_encrypted\` to match live. The other four drifts are all in-place modifications and are addressed by #226 (cost-optimization), which becomes safe to deploy on top of this.

## Trade-off
We are accepting unencrypted at-rest storage on the pre-launch DB. Zero users, zero real data. Before onboarding actual users we must migrate to an encrypted instance (snapshot → restore → cutover, one-shot downtime window). Will be logged in \`docs/PRE_LAUNCH_INFRA_CHECKLIST.md\` as part of the pre-launch must-fix list.

## Test plan
- [x] \`cdk synth\` clean.
- [ ] After merge: \`cdk deploy ListingJetDatabase\` is a no-op for Postgres, only the Redis rename (#228) applies. No "Requires replacement" events.
- [ ] Worker/API reconnect to Redis fine after RG cutover.
- [ ] #226 (cost-opt) can then rebase + deploy without Postgres replacement risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)