### PR TITLE
infra(cdk): reconcile Postgres drift to stop replacement cycles

### DIFF
--- a/infra/stacks/database.py
+++ b/infra/stacks/database.py
@@ -42,7 +42,7 @@ class DatabaseStack(Stack):
                 version=rds.PostgresEngineVersion.VER_16,
             ),
             instance_type=ec2.InstanceType.of(
-                ec2.InstanceClass.BURSTABLE4_GRAVITON, ec2.InstanceSize.SMALL,
+                ec2.InstanceClass.BURSTABLE4_GRAVITON, ec2.InstanceSize.MICRO,
             ),
             vpc=vpc,
             vpc_subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS),
@@ -51,12 +51,13 @@ class DatabaseStack(Stack):
             credentials=rds.Credentials.from_generated_secret("listingjet"),
             allocated_storage=20,
             max_allocated_storage=50,
-            # Matches live kjyxgeldpfef (unencrypted). Pre-launch only — must
-            # migrate to an encrypted instance before onboarding real users.
+            # storage_encrypted intentionally omitted: live kjyxgeldpfef was
+            # created without the property set, so emitting it at all (even
+            # =False) makes CFN treat the resource as needing replacement.
+            # Pre-launch: migrate to an encrypted instance before real users.
             # See docs/PRE_LAUNCH_INFRA_CHECKLIST.md for the cutover plan.
-            storage_encrypted=False,
-            multi_az=True,
-            backup_retention=Duration.days(7),
+            multi_az=False,
+            backup_retention=Duration.days(1),
             deletion_protection=True,
             removal_policy=RemovalPolicy.SNAPSHOT,
         )


### PR DESCRIPTION
Summary
  - Align CDK Postgres config with live kjyxgeldpfef so cdk deploy ListingJetDatabase no longer replaces the instance.
  - Two deploys today left two orphan RDS instances (~$50-70/mo bleed).
  - Unblocks PR #228's Redis rename.

  Changes (infra/stacks/database.py)
  - DBInstanceClass: SMALL → MICRO (match live)
  - multi_az: True → False (match live)
  - backup_retention: 7 days → 1 day (match live)
  - storage_encrypted=False → removed entirely — live was created without the property, so emitting it at any value triggers CFN replacement
  - deletion_protection=True unchanged

  Verification
  - cdk diff: Postgres block reduced to [~] DeletionProtection (template-state artifact; live already True → no-op)
  - cdk synth | grep StorageEncrypted: zero matches
  - Synthesized values match live: BackupRetentionPeriod: 1, DBInstanceClass: db.t4g.micro, DeletionProtection: true, MultiAZ: false

  Pre-launch must-fix: unencrypted storage. Migration plan in docs/PRE_LAUNCH_INFRA_CHECKLIST.md.

  Orphan cleanup (after deploy)
  - listingjetdatabase-postgres9dc8bb04-lfk5bsiimapu (12:18 UTC)
  - listingjetdatabase-postgres9dc8bb04-k93qto913sj1 (13:29 UTC)

  aws rds modify-db-instance --db-instance-identifier <id> --no-deletion-protection --apply-immediately
  sleep 90
  aws rds delete-db-instance --db-instance-identifier <id> --skip-final-snapshot

  Test plan
  - cdk diff on branch shows Postgres = only [~] DeletionProtection
  - Redis block shows expected CacheCluster → ReplicationGroup
  - Post-merge cdk deploy ListingJetDatabase hits UPDATE_COMPLETE without creating a new Postgres instance
  - describe-db-instances shows only kjyxgeldpfef + 2 existing orphans (no third)
  - Redis rename completes
  - Orphans deleted