### PR TITLE
fix(config): drop stale listingjet-dev default for s3_bucket_name

### DIFF
--- a/src/listingjet/config/__init__.py
+++ b/src/listingjet/config/__init__.py
@@ -78,7 +78,7 @@ class Settings(BaseSettings):
     frontend_url: str = "https://listingjet.ai"
 
     # S3
-    s3_bucket_name: str = "listingjet-dev"
+    s3_bucket_name: str = ""
     aws_region: str = "us-east-1"
 
     # Monitoring


### PR DESCRIPTION
The deleted listingjet-dev bucket was the default fallback; empty default now forces an explicit S3_BUCKET_NAME env var instead of silently pointing writes at a bucket that no longer exists.