### PR TITLE
chore(cdk): set min_healthy_percent=100 on ECS services

### DIFF
--- a/infra/stacks/services.py
+++ b/infra/stacks/services.py
@@ -195,6 +195,7 @@ class ServicesStack(Stack):
             protocol=elbv2.ApplicationProtocol.HTTP,
             assign_public_ip=False,
             service_name="listingjet-api",
+            min_healthy_percent=100,
         )
 
         self.api_service.target_group.configure_health_check(
@@ -330,6 +331,7 @@ class ServicesStack(Stack):
             desired_count=1,
             service_name="listingjet-worker",
             assign_public_ip=False,
+            min_healthy_percent=100,
             capacity_provider_strategies=[
                 ecs.CapacityProviderStrategy(
                     capacity_provider="FARGATE_SPOT",
@@ -377,5 +379,6 @@ class ServicesStack(Stack):
             desired_count=1,
             service_name="listingjet-temporal",
             assign_public_ip=False,
+            min_healthy_percent=100,
             cloud_map_options=ecs.CloudMapOptions(name="temporal"),
         )


### PR DESCRIPTION
CDK synth warned on every run that ApiService, WorkerService, and TemporalService all default to `min_healthy_percent=50` — which with `desired_count=1` means 0 healthy tasks mid-deploy. This sets min=100 so ECS starts the new task before draining the old one (standard zero-downtime rolling deploy).

Verified with `cdk diff ListingJetServices`: only three `MinimumHealthyPercent: 50 → 100` flips, no other changes. The three "minHealthyPercent has not been configured" warnings are gone.