### PR TITLE
fix(ci): repair Deploy to AWS workflow (task def discovery)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,23 +79,39 @@ jobs:
           REGISTRY: ${{ steps.ecr.outputs.registry }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          # Derive network config from the running API service so we don't need
-          # to duplicate subnets/security-groups as separate secrets.
-          NETWORK_CONFIG=$(aws ecs describe-services \
+          # Derive network config + task definition + container name from the
+          # running API service. The task def family is CDK-generated
+          # (e.g. ListingJetServicesApiTaskCC6F2D94), so hardcoding the ECR
+          # repo name as the family fails with "TaskDefinition not found".
+          # The container name inside the CDK task def is "api", not the ECR
+          # repo name either.
+          SERVICE_JSON=$(aws ecs describe-services \
             --cluster $ECS_CLUSTER \
             --services $ECS_SERVICE_API \
-            --query 'services[0].networkConfiguration' \
+            --query 'services[0]' \
             --output json)
+          NETWORK_CONFIG=$(echo "$SERVICE_JSON" | jq -c '.networkConfiguration')
+          TASK_DEF_ARN=$(echo "$SERVICE_JSON" | jq -r '.taskDefinition')
+          CONTAINER_NAME=$(aws ecs describe-task-definition \
+            --task-definition "$TASK_DEF_ARN" \
+            --query 'taskDefinition.containerDefinitions[0].name' \
+            --output text)
+
+          echo "Task definition: $TASK_DEF_ARN"
+          echo "Container name:  $CONTAINER_NAME"
 
           # Run a one-shot Fargate task with CMD=migrate against the current
           # task definition. The 'migrate' entrypoint exits non-zero on failure,
           # which propagates here so the deploy is aborted before traffic shifts.
+          OVERRIDES=$(jq -nc \
+            --arg name "$CONTAINER_NAME" \
+            '{containerOverrides: [{name: $name, command: ["migrate"]}]}')
           TASK_ARN=$(aws ecs run-task \
             --cluster $ECS_CLUSTER \
-            --task-definition $ECR_REPO_API \
+            --task-definition "$TASK_DEF_ARN" \
             --launch-type FARGATE \
             --network-configuration "$NETWORK_CONFIG" \
-            --overrides "{\"containerOverrides\":[{\"name\":\"$ECR_REPO_API\",\"command\":[\"migrate\"]}]}" \
+            --overrides "$OVERRIDES" \
             --query 'tasks[0].taskArn' \
             --output text)
 


### PR DESCRIPTION
## Summary

The **Deploy to AWS** workflow has failed on every merge to `main` since ~#235 (5 consecutive failures as of 2026-04-17). Backend code has silently stopped auto-deploying. Docs-only PRs masked the problem because the running image was already correct for what they changed.

## Root cause

The `Run database migrations` step called:

```
aws ecs run-task \
  --task-definition $ECR_REPO_API              # => "listingjet-api"
  --overrides "{... name: \"$ECR_REPO_API\" ... command: [migrate]}"
```

Both assumptions are wrong against the CDK-managed task defs:

- Actual task-definition **family** is CDK-generated: `ListingJetServicesApiTaskCC6F2D94`. No `listingjet-api` family exists → every run-task call fails with `TaskDefinition not found` (exit 254).
- Actual **container name** inside that task def is `api`, not the ECR repo name. Even if the family existed, the container override would miss and nothing would run.

## Fix

Derive both values at runtime from the running API service:

- `TASK_DEF_ARN` ← `aws ecs describe-services --query 'services[0].taskDefinition'`
- `CONTAINER_NAME` ← `aws ecs describe-task-definition --query 'taskDefinition.containerDefinitions[0].name'`
- `OVERRIDES` ← built with `jq -nc`

This survives future CDK renames (the service always points to the current task def) and avoids drift between workflow env vars and CFN-generated names.

## Evidence

- Latest failed run: `24580266120` (2026-04-17 18:20 UTC) — failure log: `TaskDefinition not found` while `IMAGE_TAG=66e04e2...`
- Task def inspected live: family `ListingJetServicesApiTaskCC6F2D94`, container `api`, image `.../listingjet-api:latest`
- Production services currently healthy because they're still running the last image that ECR received (`25bdfa7...` from #241 deploy)

## Side effect of broken CI

- Worker ECR image is 11 days stale (pushed 2026-04-06). After this PR lands, the next merge to `main` will redeploy both services and catch the worker up.

## Test plan

- [ ] CI: `Lint` + `Test` + `Docker Build` stay green on this PR
- [ ] After merge: watch `Deploy to AWS` run on `main` — `Run database migrations` step should print the task def ARN + container name, migrations should complete exit 0
- [ ] After deploy: `aws ecs describe-services` shows a new rollout in progress for both `listingjet-api` and `listingjet-worker`; worker image date becomes current

🤖 Generated with [Claude Code](https://claude.com/claude-code)