### PR TITLE
fix(ci): hardcode migration container name (avoid DescribeTaskDefinition)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,10 +92,11 @@ jobs:
             --output json)
           NETWORK_CONFIG=$(echo "$SERVICE_JSON" | jq -c '.networkConfiguration')
           TASK_DEF_ARN=$(echo "$SERVICE_JSON" | jq -r '.taskDefinition')
-          CONTAINER_NAME=$(aws ecs describe-task-definition \
-            --task-definition "$TASK_DEF_ARN" \
-            --query 'taskDefinition.containerDefinitions[0].name' \
-            --output text)
+          # Container name matches the CDK construct in infra/stacks/services.py
+          # (`api_task.add_container("api", ...)`). Hardcoded because the GitHub
+          # deploy role lacks ecs:DescribeTaskDefinition. If the container is ever
+          # renamed in the CDK stack, update this string.
+          CONTAINER_NAME="api"
 
           echo "Task definition: $TASK_DEF_ARN"
           echo "Container name:  $CONTAINER_NAME"


### PR DESCRIPTION
## Summary

Follow-up to #245. After that merge, the deploy workflow got past the `TaskDefinition not found` error but failed on the next AWS call:

```
AccessDeniedException: User arn:aws:sts::265911026550:assumed-role/listingjet-github-deploy/GitHubActions
is not authorized to perform: ecs:DescribeTaskDefinition on resource: *
```

Run: `24581951591` (merge commit `68b6e27`).

## Fix

The `DescribeTaskDefinition` call was only there to discover the container name. The container is named `api` in the CDK construct (`infra/stacks/services.py:148`), so we can simply hardcode it and skip the IAM-blocked API call entirely. Task definition family is still discovered dynamically, so CDK-generated family renames remain handled.

## Alternative considered

Widening the `listingjet-github-deploy` role with `ecs:DescribeTaskDefinition` would need a CDK change + `cdk deploy`. A one-line hardcode is smaller, reversible, and matches source of truth. If the container is ever renamed in CDK, the string in this workflow should be updated in the same PR.

## Test plan

- [ ] After merge: `Deploy to AWS` run on `main` completes green through `Run database migrations` and `Deploy API service` steps
- [ ] ECR `listingjet-worker:latest` timestamp advances from 2026-04-06 to current
- [ ] `aws ecs describe-services` shows new rollout on both api + worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)