### PR TITLE
fix(ci): push Docker image to listingjet-worker ECR (worker was redeploying stale image)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,14 +65,25 @@ jobs:
         id: ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Build and push API image
+      - name: Build and push API + Worker image
         env:
           REGISTRY: ${{ steps.ecr.outputs.registry }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $REGISTRY/$ECR_REPO_API:$IMAGE_TAG -t $REGISTRY/$ECR_REPO_API:latest .
+          # API and worker share the same Dockerfile; the entrypoint selects
+          # api (uvicorn) vs worker (Temporal) mode by env. Tag the single
+          # build to both ECR repos so the worker service (which pulls from
+          # listingjet-worker:latest per services.py:274) stays in sync with main.
+          docker build \
+            -t $REGISTRY/$ECR_REPO_API:$IMAGE_TAG \
+            -t $REGISTRY/$ECR_REPO_API:latest \
+            -t $REGISTRY/$ECR_REPO_WORKER:$IMAGE_TAG \
+            -t $REGISTRY/$ECR_REPO_WORKER:latest \
+            .
           docker push $REGISTRY/$ECR_REPO_API:$IMAGE_TAG
           docker push $REGISTRY/$ECR_REPO_API:latest
+          docker push $REGISTRY/$ECR_REPO_WORKER:$IMAGE_TAG
+          docker push $REGISTRY/$ECR_REPO_WORKER:latest
 
       - name: Run database migrations
         env:


### PR DESCRIPTION
## Summary

Follow-up to #245 / #246. Now that the Deploy to AWS workflow is green end-to-end, I noticed the worker service still runs stale code. Root cause:

- Worker task def pulls from `265911026550.dkr.ecr.us-east-1.amazonaws.com/listingjet-worker:latest` (confirmed via `describe-task-definition`; source: `infra/stacks/services.py:274`)
- The Build step in `deploy.yml` only built/tagged/pushed `$ECR_REPO_API` (listingjet-api)
- Nothing ever pushed to `listingjet-worker`, so its `:latest` tag has been frozen at **2026-04-06** for 11 days
- Every `force-new-deployment` on the worker service just pulled the same old digest

## Fix

Tag the single Docker build to **both** ECR repos and push to both. API and worker share the Dockerfile — the entrypoint picks api (uvicorn) vs worker (Temporal) mode by env. No extra build cost.

## Test plan

- [ ] After merge: `Deploy to AWS` run completes green
- [ ] `aws ecr describe-images --repository-name listingjet-worker` shows `latest` with today's timestamp and a SHA-tagged image matching `github.sha`
- [ ] ECS worker service rolls out and its new task picks up today's image

🤖 Generated with [Claude Code](https://claude.com/claude-code)