### PR TITLE
revert(ci): drop worker ECR push until IAM grant lands

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,25 +65,18 @@ jobs:
         id: ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Build and push API + Worker image
+      - name: Build and push API image
         env:
           REGISTRY: ${{ steps.ecr.outputs.registry }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          # API and worker share the same Dockerfile; the entrypoint selects
-          # api (uvicorn) vs worker (Temporal) mode by env. Tag the single
-          # build to both ECR repos so the worker service (which pulls from
-          # listingjet-worker:latest per services.py:274) stays in sync with main.
-          docker build \
-            -t $REGISTRY/$ECR_REPO_API:$IMAGE_TAG \
-            -t $REGISTRY/$ECR_REPO_API:latest \
-            -t $REGISTRY/$ECR_REPO_WORKER:$IMAGE_TAG \
-            -t $REGISTRY/$ECR_REPO_WORKER:latest \
-            .
+          # TODO: also push to $ECR_REPO_WORKER once the listingjet-github-deploy
+          # role has grant_pull_push on worker_repo (add in infra/stacks/ci.py +
+          # cdk deploy). Without that grant the push fails with
+          # `ecr:InitiateLayerUpload denied`. See PR #247 (reverted here).
+          docker build -t $REGISTRY/$ECR_REPO_API:$IMAGE_TAG -t $REGISTRY/$ECR_REPO_API:latest .
           docker push $REGISTRY/$ECR_REPO_API:$IMAGE_TAG
           docker push $REGISTRY/$ECR_REPO_API:latest
-          docker push $REGISTRY/$ECR_REPO_WORKER:$IMAGE_TAG
-          docker push $REGISTRY/$ECR_REPO_WORKER:latest
 
       - name: Run database migrations
         env:


### PR DESCRIPTION
## Summary

Reverts the worker-push lines from PR #247. That PR tagged the single Docker build to both ECR repos, but the push to `listingjet-worker` failed because the `listingjet-github-deploy` IAM role only has `grant_pull_push` on `api_repo` (see `infra/stacks/ci.py:54`):

```
denied: User arn:aws:sts::.../listingjet-github-deploy/GitHubActions
is not authorized to perform: ecr:InitiateLayerUpload on resource:
.../repository/listingjet-worker
```

Failing run: `24584951813`.

## Why revert now

CI is currently broken on `main` — every future merge's deploy step dies in the build/push. Restoring green CI is priority 1. A TODO comment marks the push site so the full fix isn't forgotten.

## Follow-up (separate PR)

1. Add `worker_repo.grant_pull_push(self.deploy_role)` to `infra/stacks/ci.py` (mirror of the existing `api_repo` grant at line 54).
2. `cdk deploy ListingJetCI` (manual — existing process).
3. Re-apply the worker push lines in this workflow (revert-of-revert).

Once that ships, the worker service will finally pick up current `main` on each deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)