### PR TITLE
fix(infra): grant deploy role push on listingjet-worker ECR

### DIFF
--- a/infra/app.py
+++ b/infra/app.py
@@ -46,6 +46,7 @@ monitoring = MonitoringStack(
 ci = CIStack(
     app, "ListingJetCI",
     api_repo=services.api_repo,
+    worker_repo=services.worker_repo,
     cluster=services.cluster,
     env=env,
 )

--- a/infra/stacks/ci.py
+++ b/infra/stacks/ci.py
@@ -21,6 +21,7 @@ class CIStack(Stack):
         scope: Construct,
         id: str,
         api_repo: ecr.IRepository,
+        worker_repo: ecr.IRepository,
         cluster: ecs.ICluster,
         **kwargs,
     ) -> None:
@@ -50,8 +51,10 @@ class CIStack(Stack):
             ),
         )
 
-        # ECR push permissions
+        # ECR push permissions — both repos share a Dockerfile; the deploy
+        # workflow tags one build to both and pushes.
         api_repo.grant_pull_push(self.deploy_role)
+        worker_repo.grant_pull_push(self.deploy_role)
 
         # ECS deploy permissions
         self.deploy_role.add_to_policy(


### PR DESCRIPTION
## Summary

Unblocks the worker image staleness finding from the health check. The `listingjet-github-deploy` role has `grant_pull_push` on `api_repo` but not `worker_repo` — this PR mirrors the grant.

Companion fix for PRs #247 (attempt) / #248 (revert). After this merges and `cdk deploy` runs, we can revert-the-revert and re-enable the worker push in `deploy.yml`.

## Changes

- `infra/stacks/ci.py`: add `worker_repo: ecr.IRepository` ctor param + `worker_repo.grant_pull_push(self.deploy_role)` (mirror of api_repo line)
- `infra/app.py`: pass `worker_repo=services.worker_repo` into `CIStack`

## cdk diff (verified locally)

**ListingJetCI** — one new IAM statement on `DeployRole`:

```
Resource: WorkerRepo ARN (cross-stack import)
Effect: Allow
Actions:
  - ecr:BatchCheckLayerAvailability
  - ecr:GetDownloadUrlForLayer
  - ecr:BatchGetImage
  - ecr:CompleteLayerUpload
  - ecr:UploadLayerPart
  - ecr:InitiateLayerUpload
  - ecr:PutImage
Principal: DeployRole
```

**ListingJetServices** — adds one output export `ExportsOutputFnGetAttWorkerRepoEE566D3EArn9AD78316` (cross-stack reference for CIStack). ECS service resources show `[~]` markers from CFN re-serializing references; no functional change.

## Deploy

```
cd infra
cdk deploy ListingJetServices ListingJetCI
```

(Both stacks — ServicesStack needs re-synth to emit the new output export that CIStack imports.)

## Follow-up PR

After this is deployed, I'll open a small PR to re-apply the worker push lines in `.github/workflows/deploy.yml` (revert of #248). TODO comment is already at the push site.

## Test plan

- [ ] After `cdk deploy`: `aws iam get-role-policy listingjet-github-deploy ...` shows the new ECR statement for WorkerRepo
- [ ] Merge follow-up PR to re-enable worker push
- [ ] Next push to `main` builds + pushes to both ECR repos; `aws ecr describe-images --repository-name listingjet-worker` shows a fresh timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)