### PR TITLE
chore(ci): bump Node-20 deprecated actions to v6 + clarify deploy step name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,8 +40,8 @@ jobs:
       REDIS_URL: "redis://localhost:6379/0"
       USE_MOCK_PROVIDERS: "true"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: pip install -e ".[dev]"
@@ -53,10 +53,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -145,7 +145,7 @@ jobs:
           fi
           echo "Migrations completed successfully (exit 0)"
 
-      - name: Deploy API service
+      - name: Deploy API + Worker services
         run: |
           aws ecs update-service --cluster $ECS_CLUSTER --service $ECS_SERVICE_API --force-new-deployment
           aws ecs update-service --cluster $ECS_CLUSTER --service $ECS_SERVICE_WORKER --force-new-deployment

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -31,7 +31,7 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,10 +56,10 @@ jobs:
       USE_MOCK_PROVIDERS: "true"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary
GitHub is forcing Node.js 24 as the runner default on **2026-06-02** and removing Node 20 on **2026-09-16**. The 2026-04-17 deploy run surfaced the deprecation warnings for three actions; bumping them ahead of the deadline.

| Action | Was | Now | Files touched |
|---|---|---|---|
| `actions/checkout` | v4 | v6 | deploy, docker, lint, test |
| `actions/setup-python` | v5 | v6 | deploy, lint, test |
| `aws-actions/configure-aws-credentials` | v4 | v6 | deploy |

Also rename deploy.yml's `Deploy API service` step → `Deploy API + Worker services`. The step already force-redeploys **both** ECS services (line 151 — `update-service --service $ECS_SERVICE_WORKER --force-new-deployment`); the old name just made it look like the worker wasn't being refreshed.

## Test plan
- [ ] PR CI (`test`, `lint`) passes on v6 runners
- [ ] After merge, `deploy.yml` run emits no "Node.js 20 actions are deprecated" annotations
- [ ] OIDC auth to AWS still works (v6 of `configure-aws-credentials` keeps `role-to-assume` + `aws-region` inputs unchanged)

## Not included
Other actions in the workflows (`aws-actions/amazon-ecr-login@v2`, `actions/cache@v4`, `actions/setup-node@v4`, `docker/setup-buildx-action@v3`, `docker/build-push-action@v6`) were **not** flagged in the deprecation warning and are left alone to keep this PR tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)