### PR TITLE
fix(compose): drop stale DYNAMIC_CONFIG_FILE_PATH so local Temporal boots

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,6 @@ services:
       - POSTGRES_USER=listingjet
       - POSTGRES_PWD=password
       - POSTGRES_SEEDS=postgres
-      - DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development-sql.yaml
     ports:
       - "7233:7233"
     depends_on:


### PR DESCRIPTION
## Summary
- `temporalio/auto-setup:latest` no longer ships the default `config/dynamicconfig/development-sql.yaml` our env var was pointing at, so the container aborted on boot ("no such file or directory") and took `worker` down with it.
- Dropping the override lets auto-setup fall back to its built-in defaults — which is what we want for local dev anyway.

## Repro before fix
```
docker compose up -d
docker compose ps -a | grep temporal
# temporal  Exited (1)
# worker    Exited (1)  (dns lookup for `temporal` fails)
```

## Verified after fix
```
docker compose up -d temporal worker
docker compose ps
# temporal   Up
# worker     Up (healthy)
```

## Test plan
- [x] Local: `docker compose up` → `temporal` and `worker` stay up
- [ ] Run a pipeline end-to-end against the local stack