### PR TITLE
docs(claude-md): strike shipped tenant admin controls from planned-work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,12 +154,6 @@ All P2/P3 feature work is complete. The full list is in `MASTER_TODO.md`. Notabl
 
 ---
 
-## Planned work — not yet shipped
-
-- **Tenant admin controls** — soft-delete (`deactivated_at`), `bypass_limits`, and `plan_overrides` columns on `tenants`. Previously listed here as shipped under "migration 050", but neither the migration nor the model changes ever landed (verified 2026-04-20: no occurrence of those identifiers anywhere in the repo; last migration on disk is `049_team_invite_tokens`). Scope for a future PR: migration adding the three columns, `Tenant` model fields, auth/resolution filter on `deactivated_at`, quota/rate-limit bypass on `bypass_limits`, tier-config merge for `plan_overrides`, admin API endpoints. Touches auth + billing — requires manual review per the branching rules below.
-
----
-
 ## Remaining P0 items (production blockers)
 
 These all require **external AWS actions** — no code changes needed, just ops work:


### PR DESCRIPTION
## Summary
Strike the `Planned work — not yet shipped` section now that its only entry (tenant admin controls) shipped via PR #257.

**What landed in #257:** migration 050 (`deactivated_at`, `bypass_limits`, `plan_overrides`), Tenant model columns, auth filter in `get_current_user`/`get_tenant`, quota bypass in `listing_creation` + `listings_media`, plan-override merge in `plan_limits.get_limits(...)`, and four admin endpoints (`/admin/tenants/{id}/deactivate|activate|bypass-limits|plan-overrides`).

Docs-only cleanup — no code changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GxT9t85jdnZt2FQSb6RGPU)_