### PR TITLE
docs: strike stale staging-env references (staging was never built)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,6 @@ All P2/P3 feature work is complete. The full list is in `MASTER_TODO.md`. Notabl
 - API versioning (`/v1` prefix on all routes); test suite uses transport-level path rewriting so no test changes needed
 - XGBoost phase 2 weight scoring in `weight_manager.py`
 - CI: `test.yml` has frontend job + coverage; `deploy.yml` has Trivy CRITICAL scan + worker image push
-- `staging.yml` workflow: push to `staging` branch → test → build → migrate → deploy → smoke test (`/health` + `/ready`)
 - Release automation: `.releaserc.json` + `release.yml` (semantic-release on `main`)
 - LocalStack in `docker-compose.yml` for local S3 mock
 - MLS image resize profiles (`MLS_PROFILES` in `mls_export.py`)
@@ -195,21 +194,6 @@ See `docs/PRE_LAUNCH_INFRA_CHECKLIST.md` — infra was deliberately undersized w
 
 ### 4. Cost data to collect (after 7–14 days of traffic)
 See `MASTER_TODO.md` "Cost Optimization" section — list of AWS Cost Explorer / Compute Optimizer / CloudWatch queries to run and bring back for right-sizing decisions.
-
----
-
-## Staging environment setup (new — needs wiring)
-
-`staging.yml` workflow is ready but needs these GitHub secrets/vars configured under the **`staging` environment** in repo settings:
-
-| Name | Type | Value |
-|---|---|---|
-| `AWS_DEPLOY_ROLE_ARN_STAGING` | Secret | ARN of IAM role for staging deploys |
-| `STAGING_URL` | Variable | e.g. `https://api-staging.listingjet.com` |
-
-Staging ECS resources expected:
-- Cluster: `listingjet-staging`
-- Services: `listingjet-api-staging`, `listingjet-worker-staging`
 
 ---
 

--- a/PROJECT_OVERVIEW_FOR_LLM.md
+++ b/PROJECT_OVERVIEW_FOR_LLM.md
@@ -408,8 +408,9 @@ Third-party AI processing (Google Vision, Qwen, Claude, Kling, virtual staging) 
 | Test | `.github/workflows/test.yml` | push / PR — 2 Postgres service containers, backend + frontend jobs, coverage |
 | Docker | `.github/workflows/docker.yml` | push to main |
 | Deploy (prod) | `.github/workflows/deploy.yml` | push to main — test → build → migrate (ECS run-task) → deploy API/worker/temporal, Trivy CRITICAL scan |
-| Staging | `.github/workflows/staging.yml` | push to `staging` — test → build → migrate → deploy → `/health` + `/ready` smoke |
 | Release | `.github/workflows/release.yml` | push to main — semantic-release via `.releaserc.json` |
+
+No dedicated staging env; pre-prod testing happens locally via `docker-compose up` (postgres, redis, temporal, api, worker, localstack) — see `scripts/e2e_local.sh`.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -48,7 +48,7 @@ Items from the code quality audit and UX audit that need design decisions, large
 
 - **Virtual staging + object removal real output (PR #202):** Switched from DALL-E 3 text-only to gpt-image-1.5 with real image input. Before merging, eye a sample of both `stage_image()` and `remove_object()` output on real photos — the model will behave differently than the current broken hallucination.
 
-- **Team invite email template (PR #205):** The `team_member_invite` HTML template in `services/email_templates.py` is a first cut. Send yourself a real invite on staging after #205 merges to verify it renders correctly in a real inbox and the accept link round-trips through #206's frontend.
+- **Team invite email template (PR #205):** The `team_member_invite` HTML template in `services/email_templates.py` is a first cut. Send yourself a real invite on prod after #205 merges (plus the Resend SMTP wiring from #261) to verify it renders correctly in a real inbox and the accept link round-trips through #206's frontend.
 
 ## Housekeeping
 


### PR DESCRIPTION
## Summary
No staging environment exists or is planned. The decision recorded in the pre-launch readiness plan is **local docker-compose E2E + prod smoke** instead. These docs referenced a staging env that was never provisioned:

- `staging.yml` workflow — **doesn't exist** in `.github/workflows/`
- `listingjet-staging` ECS cluster — not in CDK
- `listingjet-api-staging` / `listingjet-worker-staging` ECS services — not in CDK
- `AWS_DEPLOY_ROLE_ARN_STAGING` / `STAGING_URL` — never set up

## Changes

**`CLAUDE.md`**
- Drop the "staging.yml workflow" bullet from "What's been done"
- Remove the "Staging environment setup" section (describes resources that don't exist)

**`PROJECT_OVERVIEW_FOR_LLM.md`**
- Remove the Staging row from the CI/CD workflow table
- Add a note that local `docker-compose` is the pre-prod testing target

**`TODO.md`**
- Flip "Send yourself a real invite on staging" → "on prod after Resend SMTP wiring lands" (PR #261)

Docs-only. No code changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GxT9t85jdnZt2FQSb6RGPU)_