### PR TITLE
docs: strike stale P0 + housekeeping items landed in 2026-04-22 PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,22 +157,23 @@ All P2/P3 feature work is complete. The full list is in `MASTER_TODO.md`. Notabl
 
 These all require **external AWS actions** — no code changes needed, just ops work:
 
-### 1. Wire up a working email provider
-Current prod reality (verified 2026-04-16): `email_enabled` is unset in the
-api/worker ECS task defs, so `get_email_service()` returns `NoOpEmailService`
-and **no transactional email is actually being sent**. The
-`listingjet/app` secret has `RESEND_API_KEY` set and `SMTP_PASSWORD` empty,
-but the code has no Resend integration — only `EmailService` (SMTP),
-`SESEmailService`, and `NoOpEmailService` in `src/listingjet/services/email.py`.
+### 1. Deploy the email provider wiring (code shipped — needs `cdk deploy`)
+Code wiring landed via PR #261 (2026-04-22): `EMAIL_ENABLED=true`,
+`SMTP_HOST=smtp.resend.com`, `SMTP_USER=resend`, and `SMTP_PASSWORD`
+sourced from `RESEND_API_KEY` in Secrets Manager — on both the API and
+Worker task defs in `infra/stacks/services.py`. Native Resend path is
+also wired (PR #260) but gated off (`resend_enabled=false`).
 
-Pick one and finish the wiring:
-- **Resend via SMTP relay** (simplest): set `SMTP_HOST=smtp.resend.com`,
-  `SMTP_USER=resend`, plumb `RESEND_API_KEY` → `SMTP_PASSWORD` secret,
-  set `EMAIL_ENABLED=true` in task def, redeploy.
-- **Resend native**: add `resend` Python package, write `ResendEmailService`
-  subclass, gate on a new `resend_enabled` setting.
-- **SES**: wait for prod access approval, set `SES_ENABLED=true`,
-  `EMAIL_ENABLED=true`, redeploy.
+Remaining action:
+```
+cd infra
+cdk diff ListingJetServices     # expect env-var + secret changes only
+cdk deploy ListingJetServices    # rolls task defs
+```
+
+Then smoke: `scripts/prod_smoke.sh` (validates /health, /ready, demo upload)
+and trigger `POST /v1/auth/forgot-password` on a test account to confirm
+a real email arrives.
 
 ### 2. RDS encrypted-storage migration (~30-60 min downtime)
 The live RDS instance `kjyxgeldpfef` is unencrypted. Full runbook in `docs/PRE_LAUNCH_INFRA_CHECKLIST.md` section A:

--- a/TODO.md
+++ b/TODO.md
@@ -54,4 +54,4 @@ Items from the code quality audit and UX audit that need design decisions, large
 
 - **Untracked session handoff docs:** `docs/SESSION-HANDOFF-2026-04-07-deploy.md`, `docs/SESSION-HANDOFF-2026-04-07.md`, `docs/SESSION-HANDOFF-VIDEO-QUALITY.md` — historical records of already-shipped PRs. Either commit to `docs/archive/` or delete.
 
-- **Untracked operational docs:** `docs/runbooks/secret-rotation.md` (valuable active runbook) and `scripts/smoke_resend.py` (useful email smoke test) should be committed. `frontend/UX_AUDIT.md` should either be committed as document-of-record or deleted since most items are now resolved.
+- **Untracked operational docs:** `frontend/UX_AUDIT.md` should either be committed as document-of-record or deleted since most items are now resolved. (`docs/runbooks/secret-rotation.md` and `scripts/smoke_resend.py` were committed via PR #260 on 2026-04-22.)


### PR DESCRIPTION
## Summary
Post-merge cleanup for doc claims that were accurate on 2026-04-22 morning but drifted after PRs #258-#263 landed this afternoon.

## Changes

**`CLAUDE.md` §P0 #1 "Wire up a working email provider"**

Rewrote to reflect current state:
- Code is shipped — `EMAIL_ENABLED=true` + SMTP env vars + `SMTP_PASSWORD` → `RESEND_API_KEY` secret mapping on both API and Worker task defs (PR #261).
- Native `ResendEmailService` class also available but gated off (PR #260).
- Remaining action is just `cdk deploy ListingJetServices` + smoke.

Before: "no transactional email is actually being sent" + three provider options.
After: "code shipped — needs `cdk deploy`" + explicit deploy + smoke commands.

**`TODO.md` Housekeeping section**

`docs/runbooks/secret-rotation.md` and `scripts/smoke_resend.py` landed via PR #260. Only `frontend/UX_AUDIT.md` is still in question. Rewrote the line to keep the open question while noting what's resolved.

Docs-only. No code changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GxT9t85jdnZt2FQSb6RGPU)_