### PR TITLE
chore(infra): Phase 1 — break db_instance dependency chain (RDS reconciliation prep)

### DIFF
--- a/docs/plans/2026-04-21-cdk-rds-encryption-reconciliation.md
+++ b/docs/plans/2026-04-21-cdk-rds-encryption-reconciliation.md
@@ -149,25 +149,28 @@ Live RDS `listingjet-postgres-encrypted` is protected by `DeletionProtection=Tru
 
 ---
 
-## Open questions (resolve before starting)
+## Open questions — RESOLVED 2026-04-22
 
-1. **Does the CDK-generated secret for the old instance still exist?**
-   - The construct used `rds.Credentials.from_generated_secret("listingjet")` — CDK created `ListingJetDatabasePostgresS-2g2B0n8yjwAF-DRYvqm`.
-   - The encrypted instance was restored from snapshot; it re-uses the same master credentials, so the secret value is still correct for the new instance.
-   - But CFN may have orphaned the secret resource when the physical DB was deleted. Check: `aws secretsmanager describe-secret --secret-id ListingJetDatabasePostgresS-2g2B0n8yjwAF-DRYvqm`.
-   - If it exists → Phase 4 should include `credentials=rds.Credentials.from_secret(secretsmanager.Secret.from_secret_name_v2(…))` pointing at that secret.
-   - If missing → Phase 4 should use `credentials=rds.Credentials.from_password("listingjet", SecretValue.secrets_manager(...))` or manually manage.
+All four questions verified via AWS CLI against the live account before Phase 1 code was drafted.
 
-2. **Does `rds.PostgresEngineVersion.VER_16_10` exist in this CDK version?**
-   - Some CDK versions only expose major-minor. If only `VER_16` is available, may need the L1 `CfnDBInstance` construct to pin `EngineVersion` exactly.
+1. **CDK-generated secret is still alive.**
+   - `aws secretsmanager describe-secret --secret-id arn:aws:secretsmanager:us-east-1:265911026550:secret:ListingJetDatabasePostgresS-2g2B0n8yjwAF-DRYvqm` → Name `ListingJetDatabasePostgresS-2g2B0n8yjwAF`, `DeletedDate=None`, last changed 2026-04-14 (i.e., after the encryption migration).
+   - Phase 4 should wire `credentials=rds.Credentials.from_secret(sm.Secret.from_secret_complete_arn(self, "DbSecret", _DB_SECRET_ARN))`.
+   - Phase 1 already references this ARN directly (see `services.py` module-level constant).
 
-3. **Is the subnet group still tracked by CFN?**
-   - Live DB uses `listingjetdatabase-postgressubnetgroup9f8a4d6e-ixyvwsoprif1`, which looks like the CDK-generated name.
-   - Verify: `aws cloudformation describe-stack-resources --stack-name ListingJetDatabase | grep SubnetGroup`.
-   - If present, CDK will reference it normally. If orphaned, Phase 4 needs `subnet_group=rds.SubnetGroup.from_subnet_group_name(…)` explicit.
+2. **Engine version is exactly `16.10`** (`aws rds describe-db-instances …`).
+   - Use `rds.PostgresEngineVersion.VER_16_10` if available. If the CDK version in use only exposes `VER_16`, drop to `CfnDBInstance` L1 to pin `EngineVersion: "16.10"` exactly — Phase 5 `cdk import` will fail otherwise.
 
-4. **Is `alias/aws/rds` the canonical ARN or does CDK want the key ID form?**
-   - Live describe output gives key ARN. Test with ARN first; fall back to `kms.Key.from_lookup`.
+3. **Subnet group is still CFN-tracked** (logical id `PostgresSubnetGroup9F8A4D6E`, physical id `listingjetdatabase-postgressubnetgroup9f8a4d6e-ixyvwsoprif1`, status `CREATE_COMPLETE`).
+   - Phase 4 can reference it via the existing construct. No `from_subnet_group_name` lookup needed.
+
+4. **KMS key is the full ARN** `arn:aws:kms:us-east-1:265911026550:key/1482e415-1d7e-4269-b887-1a25d453cf6b` (confirmed by `DBInstance.KmsKeyId`).
+   - Phase 4 uses `kms.Key.from_key_arn(self, "DbKmsKey", <arn>)` — no lookup fallback needed.
+
+### Additional facts confirmed 2026-04-22
+
+- Stale CFN entry still present: `Postgres9DC8BB04` physical id `listingjetdatabase-postgres9dc8bb04-kjyxgeldpfef` status `UPDATE_COMPLETE`. Drift is exactly as described in the Context section.
+- Live instance: status `available`, master username `listingjet`, port `5432`, `StorageEncrypted=true`.
 
 ---
 
@@ -183,6 +186,6 @@ Live RDS `listingjet-postgres-encrypted` is protected by `DeletionProtection=Tru
 - `docs/PRE_LAUNCH_INFRA_CHECKLIST.md` §A — original encryption migration runbook (completed 2026-04-17)
 - `docs/archive/HANDOFF-SESSION-APRIL-2*.md` — prior-session handoff with the original 4-step plan
 - `infra/stacks/database.py` — module-level ⚠️ warning with superseded plan
-- `infra/stacks/services.py:90,364` — `db_instance` consumers
-- `infra/stacks/monitoring.py:122,133,227,228` — `db_instance` consumers
-- `infra/app.py:31,41` — stack-to-stack wiring
+- `infra/stacks/services.py` — `db_instance` consumers (now hardcoded via `_DB_ENDPOINT` / `_DB_SECRET_ARN` module constants after Phase 1)
+- `infra/stacks/monitoring.py` — `db_instance` consumers (now via `_rds_metric()` helper after Phase 1)
+- `infra/app.py` — stack-to-stack wiring (`db_instance=` kwargs dropped from Services + Monitoring after Phase 1)

--- a/infra/app.py
+++ b/infra/app.py
@@ -28,7 +28,6 @@ database = DatabaseStack(
 services = ServicesStack(
     app, "ListingJetServices",
     vpc=network.vpc,
-    db_instance=database.db_instance,
     redis_cluster=database.redis_cluster,
     env=env,
 )
@@ -38,7 +37,6 @@ monitoring = MonitoringStack(
     cluster=services.cluster,
     api_service=services.api_service,
     alb=services.alb,
-    db_instance=database.db_instance,
     alert_email=alert_email,
     env=env,
 )

--- a/infra/stacks/monitoring.py
+++ b/infra/stacks/monitoring.py
@@ -20,15 +20,30 @@ from aws_cdk import (
     aws_elasticloadbalancingv2 as elbv2,
 )
 from aws_cdk import (
-    aws_rds as rds,
-)
-from aws_cdk import (
     aws_sns as sns,
 )
 from aws_cdk import (
     aws_sns_subscriptions as subs,
 )
 from constructs import Construct
+
+# ⚠️ TEMPORARY — removed in Phase 6 of RDS reconciliation.
+# See docs/plans/2026-04-21-cdk-rds-encryption-reconciliation.md.
+# While `DatabaseStack.db_instance` tracks a deleted physical resource,
+# alarms and dashboards build CloudWatch metrics by DBInstanceIdentifier
+# directly against the live encrypted instance.
+_DB_INSTANCE_ID = "listingjet-postgres-encrypted"
+
+
+def _rds_metric(metric_name: str) -> cw.Metric:
+    """Build an AWS/RDS metric pinned to the live encrypted instance."""
+    return cw.Metric(
+        namespace="AWS/RDS",
+        metric_name=metric_name,
+        dimensions_map={"DBInstanceIdentifier": _DB_INSTANCE_ID},
+        statistic="Average",
+        period=Duration.minutes(5),
+    )
 
 
 class MonitoringStack(Stack):
@@ -39,7 +54,6 @@ class MonitoringStack(Stack):
         cluster: ecs.ICluster,
         api_service,
         alb: elbv2.IApplicationLoadBalancer,
-        db_instance: rds.DatabaseInstance,
         alert_email: str,
         **kwargs,
     ) -> None:
@@ -119,7 +133,7 @@ class MonitoringStack(Stack):
         # --- RDS Storage Low --------------------------------------------------
         storage_alarm = cw.Alarm(
             self, "RdsStorageLow",
-            metric=db_instance.metric_free_storage_space(),
+            metric=_rds_metric("FreeStorageSpace"),
             threshold=4 * 1024 * 1024 * 1024,  # 4 GB
             evaluation_periods=1,
             comparison_operator=cw.ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
@@ -130,7 +144,7 @@ class MonitoringStack(Stack):
         # --- RDS CPU High -----------------------------------------------------
         cpu_alarm = cw.Alarm(
             self, "RdsCpuHigh",
-            metric=db_instance.metric_cpu_utilization(),
+            metric=_rds_metric("CPUUtilization"),
             threshold=80,
             evaluation_periods=2,
             comparison_operator=cw.ComparisonOperator.GREATER_THAN_THRESHOLD,
@@ -224,8 +238,8 @@ class MonitoringStack(Stack):
                 [
                     cw.GraphWidget(
                         title="RDS CPU / Storage",
-                        left=[db_instance.metric_cpu_utilization()],
-                        right=[db_instance.metric_free_storage_space()],
+                        left=[_rds_metric("CPUUtilization")],
+                        right=[_rds_metric("FreeStorageSpace")],
                         width=12,
                     ),
                     cw.GraphWidget(

--- a/infra/stacks/services.py
+++ b/infra/stacks/services.py
@@ -32,15 +32,25 @@ from aws_cdk import (
     aws_logs as logs,
 )
 from aws_cdk import (
-    aws_rds as rds,
-)
-from aws_cdk import (
     aws_s3 as s3,
 )
 from aws_cdk import (
     aws_secretsmanager as sm,
 )
 from constructs import Construct
+
+# ⚠️ TEMPORARY — removed in Phase 6 of RDS reconciliation.
+# See docs/plans/2026-04-21-cdk-rds-encryption-reconciliation.md.
+# During reconciliation, the `db_instance` construct in DatabaseStack
+# cannot be referenced here (its logical id tracks a deleted physical
+# resource). These constants point at the live encrypted instance and
+# the still-present CDK-generated master secret. Verified 2026-04-22
+# via `aws rds describe-db-instances` and `aws secretsmanager describe-secret`.
+_DB_ENDPOINT = "listingjet-postgres-encrypted.c8xiacyu8dyh.us-east-1.rds.amazonaws.com"
+_DB_SECRET_ARN = (
+    "arn:aws:secretsmanager:us-east-1:265911026550:secret:"
+    "ListingJetDatabasePostgresS-2g2B0n8yjwAF-DRYvqm"
+)
 
 
 class ServicesStack(Stack):
@@ -49,7 +59,6 @@ class ServicesStack(Stack):
         scope: Construct,
         id: str,
         vpc: ec2.IVpc,
-        db_instance: rds.DatabaseInstance,
         redis_cluster: elasticache.CfnReplicationGroup,
         **kwargs,
     ) -> None:
@@ -87,7 +96,12 @@ class ServicesStack(Stack):
         )
 
         # Shared secrets
-        db_secret = db_instance.secret
+        # ⚠️ TEMPORARY: `db_instance.secret` is unreachable during RDS
+        # reconciliation — see top-of-file note. Reference the CDK-generated
+        # master secret by ARN directly so task defs still get username/password.
+        db_secret = sm.Secret.from_secret_complete_arn(
+            self, "DbSecretRef", _DB_SECRET_ARN,
+        )
         app_secrets = sm.Secret.from_secret_name_v2(
             self, "AppSecrets", "listingjet/app",
         )
@@ -375,7 +389,9 @@ class ServicesStack(Stack):
             environment={
                 "DB": "postgres12",
                 "DB_PORT": "5432",
-                "POSTGRES_SEEDS": db_instance.db_instance_endpoint_address,
+                # ⚠️ TEMPORARY: hardcoded during RDS reconciliation — swap
+                # back to `db_instance.db_instance_endpoint_address` in Phase 6.
+                "POSTGRES_SEEDS": _DB_ENDPOINT,
             },
             secrets={
                 "POSTGRES_USER": ecs.Secret.from_secrets_manager(db_secret, "username"),


### PR DESCRIPTION
## Summary

Phase 1 of the CDK RDS encryption reconciliation plan (`docs/plans/2026-04-21-cdk-rds-encryption-reconciliation.md`). Prepares `ServicesStack` + `MonitoringStack` to synth without referencing `DatabaseStack.db_instance` so Phases 3+5 can safely delete and re-add the RDS construct.

**Resolved all 4 open questions in the plan doc** via AWS CLI probes before drafting code:
1. CDK-generated secret `ListingJetDatabasePostgresS-2g2B0n8yjwAF` is still alive (`DeletedDate=None`, last changed 2026-04-14). ARN hardcoded as `_DB_SECRET_ARN`.
2. Engine version is exactly `16.10` — recorded for Phase 4.
3. Subnet group `PostgresSubnetGroup9F8A4D6E` still CFN-tracked — Phase 4 can reference normally.
4. KMS key ARN `arn:aws:kms:us-east-1:265911026550:key/1482e415-1d7e-4269-b887-1a25d453cf6b` confirmed — recorded for Phase 4.

## Changes

- **`infra/stacks/services.py`** — drop `db_instance` param; add `_DB_ENDPOINT` + `_DB_SECRET_ARN` module constants; swap `db_instance.secret` → `Secret.from_secret_complete_arn(…)`; swap `db_instance.db_instance_endpoint_address` → `_DB_ENDPOINT` in Temporal task def.
- **`infra/stacks/monitoring.py`** — drop `db_instance` param; add `_rds_metric()` helper that constructs `AWS/RDS` metrics by `DBInstanceIdentifier`; replace all four `db_instance.metric_*` calls.
- **`infra/app.py`** — stop passing `db_instance=database.db_instance` to `ServicesStack` + `MonitoringStack`.
- **Plan doc** — record resolved values for the 4 open questions.

## Verification

- `cdk synth ListingJetServices ListingJetMonitoring` — passes.
- Synthesized `POSTGRES_SEEDS` in the Temporal task def resolves to a plain string (`listingjet-postgres-encrypted.c8xiacyu8dyh.us-east-1.rds.amazonaws.com`), not `Fn::GetAtt` to the stale logical id.

## Deploy guidance

**Per the plan doc, Phase 1 is prep only — do not deploy standalone.** Deploy happens after Phases 2–5 complete.

That said, the Services deploy is technically independent of the Database reconciliation. Deploying `ListingJetServices` with Phase 1 code would unblock the Temporal crashloop immediately (the task def env var would flip from the old `…kjyxgeldpfef…` endpoint to the encrypted endpoint). Phase 6 will later swap the hardcode back to the CDK ref, which is cosmetic churn, not a real cost. If the Temporal fix is urgent, consider deploying Services now; otherwise follow the plan.

## Test plan

- [x] `cdk synth ListingJetServices ListingJetMonitoring` passes
- [x] Synthesized POSTGRES_SEEDS is literal string matching live endpoint
- [x] Python syntax check on all 3 edited files
- [ ] When executing Phase 2: confirm RemovalPolicy flip deploys cleanly
- [ ] When executing Phase 6: confirm POSTGRES_SEEDS flips back to CDK ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)