### PR TITLE
infra: reconcile RDS encryption drift via parallel-import pivot

### DIFF
--- a/infra/app.py
+++ b/infra/app.py
@@ -29,6 +29,8 @@ services = ServicesStack(
     app, "ListingJetServices",
     vpc=network.vpc,
     redis_cluster=database.redis_cluster,
+    db_instance=database.db_instance_encrypted,
+    db_secret=database.db_secret_encrypted,
     env=env,
 )
 
@@ -37,6 +39,7 @@ monitoring = MonitoringStack(
     cluster=services.cluster,
     api_service=services.api_service,
     alb=services.alb,
+    db_instance=database.db_instance_encrypted,
     alert_email=alert_email,
     env=env,
 )

--- a/infra/stacks/database.py
+++ b/infra/stacks/database.py
@@ -1,34 +1,40 @@
 """RDS PostgreSQL and ElastiCache Redis.
 
-⚠️  CDK DRIFT WARNING — encryption migration 2026-04-17 ⚠️
+⚠️  CDK RECONCILIATION — encryption migration, zombie-resource path (2026-04-23) ⚠️
 
-The live RDS instance for this stack is now
-`listingjet-postgres-encrypted` (StorageEncrypted=True, restored from an
-encrypted snapshot of the old `listingjetdatabase-postgres9dc8bb04-kjyxgeldpfef`
-instance, which has been deleted). That migration was done via `aws rds`
-CLI, NOT through CDK, so CloudFormation still thinks this stack's `Postgres`
-logical resource is the deleted physical instance.
+History: the live RDS instance for this stack is
+`listingjet-postgres-encrypted` (StorageEncrypted=True, restored
+2026-04-17 from an encrypted snapshot of the old
+`listingjetdatabase-postgres9dc8bb04-kjyxgeldpfef` instance, which has
+been deleted). That migration was done via `aws rds` CLI, NOT CDK, so
+CloudFormation's `Postgres` logical id (Postgres9DC8BB04) points at a
+physical resource that returns 404 on any describe.
 
-DO NOT run `cdk deploy` on `ListingJetDatabase` until this drift is
-reconciled. A normal deploy here would at best fail, at worst recreate a
-brand-new empty Postgres on top of the real data.
+Reconciliation attempted 2026-04-23 with the RETAIN-flip → remove →
+re-add → import plan. RETAIN flip failed: CFN's v2 RDS resource
+provider calls `describe-db-instances` on any logical-resource update
+(including pure metadata changes like DeletionPolicy) and the 404 is
+terminal. Remove-and-recreate would have the same failure mode during
+the implicit DELETE.
 
-Reconciliation plan (future session):
-1. Rewrite this construct with `removal_policy=RemovalPolicy.RETAIN` and
-   remove the `Postgres` resource from the template.
-2. `cdk deploy` to release the (now missing) old resource from CFN
-   tracking without deleting anything.
-3. Re-add `Postgres` with `storage_encrypted=True` and all other
-   properties matching the live new instance.
-4. `cdk import` to adopt the live new instance under the same logical
-   ID — CFN requires every property to match exactly, so expect a few
-   retry cycles.
+Pivoted to the zombie-resource path:
+- The original `Postgres` construct below is LEFT UNCHANGED. Its
+  synthesized resources (Postgres9DC8BB04, the generated secret, the
+  secret attachment) are CFN zombies — present in the template and in
+  CFN state, but the underlying AWS resources are gone. Do NOT attempt
+  any mutation on them; every mutation will fail.
+- A parallel `PostgresEncrypted` construct below adopts the live
+  encrypted instance via `cdk import`, reusing the existing (still-alive)
+  subnet group + KMS key + secret. Downstream code (services.py,
+  monitoring.py) wires off `self.db_instance_encrypted`.
+- The subnet group `PostgresSubnetGroup9F8A4D6E` is NOT a zombie: its
+  physical resource is alive and in use by the live encrypted
+  instance. Leaving the old construct's auto-generated subnet group in
+  place keeps the live instance's subnet group tracked correctly.
 
-Until then: app runs fine (DATABASE_URL secret already points at the
-new instance); Redis + SGs + subnet group in this stack are untouched
-and safe to `cdk deploy` individually via `--exclusively` if needed.
-
-See `docs/PRE_LAUNCH_INFRA_CHECKLIST.md` §A for the original runbook.
+If you ever need to clean up the zombies: that requires delete-stack
+--retain-resources rebuild work, not worth it unless we're consolidating
+infra later.
 """
 
 from aws_cdk import (
@@ -43,7 +49,13 @@ from aws_cdk import (
     aws_elasticache as elasticache,
 )
 from aws_cdk import (
+    aws_kms as kms,
+)
+from aws_cdk import (
     aws_rds as rds,
+)
+from aws_cdk import (
+    aws_secretsmanager as sm,
 )
 from constructs import Construct
 
@@ -97,6 +109,76 @@ class DatabaseStack(Stack):
             backup_retention=Duration.days(1),
             deletion_protection=True,
             removal_policy=RemovalPolicy.SNAPSHOT,
+        )
+
+        # --- RDS PostgreSQL 16 (ENCRYPTED, zombie-path re-add) ---------------
+        # The construct above is a zombie (see file header). The live
+        # encrypted instance `listingjet-postgres-encrypted` is adopted
+        # here via `cdk import` under a NEW logical id. Exact-match
+        # properties against the live instance are required or import
+        # fails; values below were verified 2026-04-23 against
+        # `aws rds describe-db-instances --db-instance-identifier
+        # listingjet-postgres-encrypted`.
+        # NOTE: `rds.Credentials.from_secret()` would implicitly create
+        # an AWS::SecretsManager::SecretTargetAttachment — a NEW resource
+        # that `cdk import` cannot create alongside the adopted instance
+        # (CFN import only adopts existing resources). Using
+        # `from_password` with a dynamic secret reference avoids the
+        # attachment entirely; the live secret already has the correct
+        # host/port from the restore, so no attachment is needed.
+
+        self.db_secret_encrypted = sm.Secret.from_secret_complete_arn(
+            self,
+            "EncryptedDbSecret",
+            (
+                "arn:aws:secretsmanager:us-east-1:265911026550:secret:"
+                "ListingJetDatabasePostgresS-2g2B0n8yjwAF-DRYvqm"
+            ),
+        )
+        encrypted_db_kms_key = kms.Key.from_key_arn(
+            self,
+            "EncryptedDbKmsKey",
+            (
+                "arn:aws:kms:us-east-1:265911026550:key/"
+                "1482e415-1d7e-4269-b887-1a25d453cf6b"
+            ),
+        )
+        encrypted_db_subnet_group = rds.SubnetGroup.from_subnet_group_name(
+            self,
+            "EncryptedDbSubnetGroup",
+            "listingjetdatabase-postgressubnetgroup9f8a4d6e-ixyvwsoprif1",
+        )
+        self.db_instance_encrypted = rds.DatabaseInstance(
+            self,
+            "PostgresEncrypted",
+            engine=rds.DatabaseInstanceEngine.postgres(
+                version=rds.PostgresEngineVersion.VER_16_10,
+            ),
+            instance_type=ec2.InstanceType.of(
+                ec2.InstanceClass.BURSTABLE4_GRAVITON,
+                ec2.InstanceSize.MICRO,
+            ),
+            vpc=vpc,
+            subnet_group=encrypted_db_subnet_group,
+            security_groups=[self.db_sg],
+            database_name="listingjet",
+            credentials=rds.Credentials.from_password(
+                "listingjet",
+                self.db_secret_encrypted.secret_value_from_json("password"),
+            ),
+            allocated_storage=20,
+            storage_type=rds.StorageType.GP2,
+            storage_encrypted=True,
+            storage_encryption_key=encrypted_db_kms_key,
+            parameter_group=rds.ParameterGroup.from_parameter_group_name(
+                self,
+                "EncryptedDbParamGroup",
+                "listingjet-pg16",
+            ),
+            multi_az=False,
+            backup_retention=Duration.days(1),
+            deletion_protection=True,
+            removal_policy=RemovalPolicy.RETAIN,
         )
 
         # --- ElastiCache Redis 7 ---------------------------------------------

--- a/infra/stacks/monitoring.py
+++ b/infra/stacks/monitoring.py
@@ -20,30 +20,15 @@ from aws_cdk import (
     aws_elasticloadbalancingv2 as elbv2,
 )
 from aws_cdk import (
+    aws_rds as rds,
+)
+from aws_cdk import (
     aws_sns as sns,
 )
 from aws_cdk import (
     aws_sns_subscriptions as subs,
 )
 from constructs import Construct
-
-# ⚠️ TEMPORARY — removed in Phase 6 of RDS reconciliation.
-# See docs/plans/2026-04-21-cdk-rds-encryption-reconciliation.md.
-# While `DatabaseStack.db_instance` tracks a deleted physical resource,
-# alarms and dashboards build CloudWatch metrics by DBInstanceIdentifier
-# directly against the live encrypted instance.
-_DB_INSTANCE_ID = "listingjet-postgres-encrypted"
-
-
-def _rds_metric(metric_name: str) -> cw.Metric:
-    """Build an AWS/RDS metric pinned to the live encrypted instance."""
-    return cw.Metric(
-        namespace="AWS/RDS",
-        metric_name=metric_name,
-        dimensions_map={"DBInstanceIdentifier": _DB_INSTANCE_ID},
-        statistic="Average",
-        period=Duration.minutes(5),
-    )
 
 
 class MonitoringStack(Stack):
@@ -54,6 +39,7 @@ class MonitoringStack(Stack):
         cluster: ecs.ICluster,
         api_service,
         alb: elbv2.IApplicationLoadBalancer,
+        db_instance: rds.IDatabaseInstance,
         alert_email: str,
         **kwargs,
     ) -> None:
@@ -133,7 +119,7 @@ class MonitoringStack(Stack):
         # --- RDS Storage Low --------------------------------------------------
         storage_alarm = cw.Alarm(
             self, "RdsStorageLow",
-            metric=_rds_metric("FreeStorageSpace"),
+            metric=db_instance.metric_free_storage_space(),
             threshold=4 * 1024 * 1024 * 1024,  # 4 GB
             evaluation_periods=1,
             comparison_operator=cw.ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
@@ -144,7 +130,7 @@ class MonitoringStack(Stack):
         # --- RDS CPU High -----------------------------------------------------
         cpu_alarm = cw.Alarm(
             self, "RdsCpuHigh",
-            metric=_rds_metric("CPUUtilization"),
+            metric=db_instance.metric_cpu_utilization(),
             threshold=80,
             evaluation_periods=2,
             comparison_operator=cw.ComparisonOperator.GREATER_THAN_THRESHOLD,
@@ -238,8 +224,8 @@ class MonitoringStack(Stack):
                 [
                     cw.GraphWidget(
                         title="RDS CPU / Storage",
-                        left=[_rds_metric("CPUUtilization")],
-                        right=[_rds_metric("FreeStorageSpace")],
+                        left=[db_instance.metric_cpu_utilization()],
+                        right=[db_instance.metric_free_storage_space()],
                         width=12,
                     ),
                     cw.GraphWidget(

--- a/infra/stacks/services.py
+++ b/infra/stacks/services.py
@@ -35,22 +35,12 @@ from aws_cdk import (
     aws_s3 as s3,
 )
 from aws_cdk import (
+    aws_rds as rds,
+)
+from aws_cdk import (
     aws_secretsmanager as sm,
 )
 from constructs import Construct
-
-# ⚠️ TEMPORARY — removed in Phase 6 of RDS reconciliation.
-# See docs/plans/2026-04-21-cdk-rds-encryption-reconciliation.md.
-# During reconciliation, the `db_instance` construct in DatabaseStack
-# cannot be referenced here (its logical id tracks a deleted physical
-# resource). These constants point at the live encrypted instance and
-# the still-present CDK-generated master secret. Verified 2026-04-22
-# via `aws rds describe-db-instances` and `aws secretsmanager describe-secret`.
-_DB_ENDPOINT = "listingjet-postgres-encrypted.c8xiacyu8dyh.us-east-1.rds.amazonaws.com"
-_DB_SECRET_ARN = (
-    "arn:aws:secretsmanager:us-east-1:265911026550:secret:"
-    "ListingJetDatabasePostgresS-2g2B0n8yjwAF-DRYvqm"
-)
 
 
 class ServicesStack(Stack):
@@ -60,6 +50,8 @@ class ServicesStack(Stack):
         id: str,
         vpc: ec2.IVpc,
         redis_cluster: elasticache.CfnReplicationGroup,
+        db_instance: rds.IDatabaseInstance,
+        db_secret: sm.ISecret,
         **kwargs,
     ) -> None:
         super().__init__(scope, id, **kwargs)
@@ -96,12 +88,6 @@ class ServicesStack(Stack):
         )
 
         # Shared secrets
-        # ⚠️ TEMPORARY: `db_instance.secret` is unreachable during RDS
-        # reconciliation — see top-of-file note. Reference the CDK-generated
-        # master secret by ARN directly so task defs still get username/password.
-        db_secret = sm.Secret.from_secret_complete_arn(
-            self, "DbSecretRef", _DB_SECRET_ARN,
-        )
         app_secrets = sm.Secret.from_secret_name_v2(
             self, "AppSecrets", "listingjet/app",
         )
@@ -389,9 +375,7 @@ class ServicesStack(Stack):
             environment={
                 "DB": "postgres12",
                 "DB_PORT": "5432",
-                # ⚠️ TEMPORARY: hardcoded during RDS reconciliation — swap
-                # back to `db_instance.db_instance_endpoint_address` in Phase 6.
-                "POSTGRES_SEEDS": _DB_ENDPOINT,
+                "POSTGRES_SEEDS": db_instance.db_instance_endpoint_address,
             },
             secrets={
                 "POSTGRES_USER": ecs.Secret.from_secrets_manager(db_secret, "username"),


### PR DESCRIPTION
## Summary

- **Pivot from the handoff plan.** The original runbook (RETAIN flip → remove → re-add → cdk import) failed because CFN's v2 RDS resource provider calls `describe-db-instances` on any metadata-only update, and `Postgres9DC8BB04` tracks the defunct pre-migration physical instance (404). Phase 2's DeletionPolicy flip and Phase 3's construct removal both hit that wall.
- **Adopted a zombie-parallel path instead.** The old `Postgres` construct stays untouched (its CFN zombies are inert as long as nothing mutates them). A new `PostgresEncrypted` construct was added alongside it and `cdk import` adopted the live `listingjet-postgres-encrypted` instance under the new logical id `PostgresEncrypted9317B6C2`.
- **Phase 6 wiring is done.** `services.py`, `monitoring.py`, `app.py` all drop the Phase 1 hardcodes (`_DB_ENDPOINT`, `_DB_SECRET_ARN`, `_DB_INSTANCE_ID`, `_rds_metric()`) and use native CDK refs — `db_instance.db_instance_endpoint_address`, `db_instance.metric_cpu_utilization()`, `db_instance.metric_free_storage_space()`. CFN synthesizes `Fn::ImportValue` cross-stack refs that resolve to the exact same live values.

## Why the handoff was wrong

The handoff claimed Phase 2's DeletionPolicy flip was "metadata-only, no AWS API call fires." CFN's modern resource provider framework calls `describe` on the target resource during ANY stack update that touches the logical resource. Reproduced twice. The handoff also missed that the live encrypted instance still uses the stack's original subnet group, so removing the old construct would cascade-delete a subnet group that's actively in use.

## Execution sequence

1. Redeployed `ListingJetMonitoring` — PR #265 patched `monitoring.py` but never actually deployed, so the alarms/dashboard still held live `Fn::ImportValue` refs to the soon-to-be-removed zombie exports. Deploying released them.
2. Deployed `ListingJetDatabase` with the new construct gated OFF to remove 3 orphaned zombie Outputs (`ExportsOutputRefPostgres9DC8BB0479C34812`, `ExportsOutputFnGetAttPostgres9DC8BB04EndpointAddress36F9722A`, `ExportsOutputRefPostgresSecretAttachment75CD6F6F9ED7447B`). Combining this with the import step failed once: CFN re-resolves `Fn::GetAtt` on post-import validation and 404'd on the zombie.
3. Flipped the construct ON, ran `cdk import ListingJetDatabase --resource-mapping resource-mapping.json`. Import succeeded first try — every property matched on the first attempt.
4. Deployed `ListingJetDatabase` again to emit the new encrypted-endpoint Outputs.
5. Deployed `ListingJetServices` + `ListingJetMonitoring` with the dehardcoded code.

## Known tech debt

`Postgres9DC8BB04`, the CDK-generated master Secret, and `PostgresSecretAttachment75CD6F6F` remain tracked by CFN as zombies. They 404 on any stack-level mutation that puts them in a change set. Nothing in the current template references them, so they're inert. Full cleanup requires a `delete-stack --retain-resources` rebuild — deferred as not worth the risk for what amounts to 3 orphaned CFN tracking entries.

## Verification

- `/health` → 200
- `/health/deep` → 200 (`database:ok, redis:ok, temporal:ok`) — confirms end-to-end DB + Redis + Temporal connectivity against the newly-tracked encrypted instance
- Temporal task def `ListingJetServicesTemporalTaskE084D0B5:8` has `POSTGRES_SEEDS=listingjet-postgres-encrypted.c8xiacyu8dyh.us-east-1.rds.amazonaws.com` (resolved from CDK cross-stack ref, not a literal string)
- Live `listingjet-postgres-encrypted` still `available`, `StorageEncrypted: True` — untouched

## Test plan

- [ ] CI passes
- [ ] Reviewer confirms the zombie construct's presence + RETAIN policy + untouched properties
- [ ] Reviewer verifies that no future `cdk deploy` touches `Postgres9DC8BB04` (no template references remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)