### PR TITLE
fix(rls): durable app.current_tenant across mid-request commits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,23 +156,9 @@ All P2/P3 feature work is complete. The full list is in `MASTER_TODO.md`. Notabl
 
 These all require **external AWS actions** — no code changes needed, just ops work:
 
-### 1. Deploy the email provider wiring (code shipped — needs `cdk deploy`)
-Code wiring landed via PR #261 (2026-04-22): `EMAIL_ENABLED=true`,
-`SMTP_HOST=smtp.resend.com`, `SMTP_USER=resend`, and `SMTP_PASSWORD`
-sourced from `RESEND_API_KEY` in Secrets Manager — on both the API and
-Worker task defs in `infra/stacks/services.py`. Native Resend path is
-also wired (PR #260) but gated off (`resend_enabled=false`).
-
-Remaining action:
-```
-cd infra
-cdk diff ListingJetServices     # expect env-var + secret changes only
-cdk deploy ListingJetServices    # rolls task defs
-```
-
-Then smoke: `scripts/prod_smoke.sh` (validates /health, /health/deep, demo upload)
-and trigger `POST /auth/forgot-password` on a test account to confirm
-a real email arrives.
+### ~~1. Email provider wiring~~ ✅ shipped + verified 2026-04-26
+Resend SMTP wiring (PR #261) is live in prod — confirmed by a real Resend
+email received in a prior session.
 
 ### 2. RDS encrypted-storage migration (~30-60 min downtime)
 The live RDS instance `kjyxgeldpfef` is unencrypted. Full runbook in `docs/PRE_LAUNCH_INFRA_CHECKLIST.md` section A:

--- a/src/listingjet/database.py
+++ b/src/listingjet/database.py
@@ -1,5 +1,5 @@
 from fastapi import Request
-from sqlalchemy import text
+from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
 
@@ -31,16 +31,26 @@ class Base(DeclarativeBase):
 async def get_db(request: Request = None):
     tenant_id = getattr(request.state, "tenant_id", None) if request else None
     async with AsyncSessionLocal() as session:
+        listener = None
         if tenant_id:
-            # SET LOCAL is transaction-scoped, so start one explicitly for it.
-            # Safe: tenant_id is a validated UUID from our JWT, not user input.
+            # SET LOCAL is transaction-scoped, so any mid-request `db.commit()`
+            # would clear `app.current_tenant` and let RLS filter subsequent
+            # reads to zero rows. Re-set the flag on every transaction the
+            # session opens via `after_begin`. Safe: tenant_id is a validated
+            # UUID from our JWT, not user input.
             tid = str(tenant_id).replace("'", "")
-            await session.execute(
-                text(f"SET LOCAL app.current_tenant = '{tid}'"),
-            )
+
+            @event.listens_for(session.sync_session, "after_begin")
+            def _set_current_tenant(_session, _transaction, connection):
+                connection.execute(text(f"SET LOCAL app.current_tenant = '{tid}'"))
+
+            listener = _set_current_tenant
         try:
             yield session
             await session.commit()
         except Exception:
             await session.rollback()
             raise
+        finally:
+            if listener is not None:
+                event.remove(session.sync_session, "after_begin", listener)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -21,3 +21,73 @@ def test_latest_rls_migration_allows_admin_context():
     assert "app.is_admin" in content
     assert "DROP POLICY IF EXISTS tenant_isolation" in content
     assert "CREATE POLICY tenant_isolation" in content
+
+
+@pytest.mark.asyncio
+async def test_get_db_resets_current_tenant_on_every_transaction(monkeypatch):
+    """`SET LOCAL app.current_tenant` is transaction-scoped and would be
+    cleared by any mid-request `db.commit()`. The dependency must hook
+    `after_begin` so the flag is re-set on every transaction the session
+    opens. Mirrors the get_db_admin guarantee."""
+    import uuid as _uuid
+    from types import SimpleNamespace
+
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session
+
+    from listingjet import database as db_mod
+
+    sync_engine = create_engine("sqlite://")
+    real_sync_session = Session(bind=sync_engine)
+    tenant_id = _uuid.uuid4()
+
+    class FakeAsyncSession:
+        def __init__(self):
+            self.sync_session = real_sync_session
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def commit(self):
+            pass
+
+        async def rollback(self):
+            pass
+
+    monkeypatch.setattr(db_mod, "AsyncSessionLocal", lambda: FakeAsyncSession())
+
+    request = SimpleNamespace(state=SimpleNamespace(tenant_id=tenant_id))
+
+    listeners_before = list(real_sync_session.dispatch.after_begin)
+
+    gen = db_mod.get_db(request=request)
+    session = await gen.__anext__()
+
+    listeners_during = list(session.sync_session.dispatch.after_begin)
+    new_listeners = [lst for lst in listeners_during if lst not in listeners_before]
+    assert len(new_listeners) == 1, "get_db must register exactly one after_begin listener"
+    listener = new_listeners[0]
+
+    executed: list[str] = []
+
+    class FakeConn:
+        def execute(self, stmt):
+            executed.append(str(stmt))
+
+    listener(session.sync_session, None, FakeConn())
+    listener(session.sync_session, None, FakeConn())
+
+    assert len(executed) == 2
+    expected = f"SET LOCAL app.current_tenant = '{tenant_id}'"
+    assert all(expected in s for s in executed)
+
+    try:
+        await gen.__anext__()
+    except StopAsyncIteration:
+        pass
+
+    remaining = list(session.sync_session.dispatch.after_begin)
+    assert listener not in remaining, "listener must be removed on session teardown"


### PR DESCRIPTION
## Summary

Sibling fix to PR #270. `get_db` had the same `SET LOCAL` bug we fixed in `get_db_admin`: the flag is transaction-scoped, so any handler that commits and then re-reads loses `app.current_tenant` and gets filtered to zero rows by RLS. Mostly hidden today because most tenant handlers commit within a single tenant scope, but it's a latent bug with the same root cause and worth fixing before it bites.

Same pattern as PR #270:
- Register an `after_begin` event listener on the session that re-issues `SET LOCAL app.current_tenant = '<tenant_id>'` on every transaction the session opens.
- Remove the listener on teardown.
- Listener captures `tenant_id` in the closure (already a validated UUID from the JWT, not user input).

Also strikes the stale email P0 from `CLAUDE.md` — Resend SMTP wiring (PR #261) is live and verified in prod.

## Test plan

- [x] `pytest tests/test_database.py::test_get_db_resets_current_tenant_on_every_transaction` — verifies the after_begin listener is registered, fires SET LOCAL with the tenant UUID on every invocation, and is removed on teardown.
- [x] `pytest tests/test_database.py` — both tests pass locally.
- [x] `ruff check src/listingjet/database.py tests/test_database.py` — clean.
- [ ] Full pytest suite (needs Postgres reachable; not run locally — CI will cover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)