### PR TITLE
docs: strike stale RDS encryption P0 — shipped via PR #268

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,10 +160,15 @@ These all require **external AWS actions** — no code changes needed, just ops 
 Resend SMTP wiring (PR #261) is live in prod — confirmed by a real Resend
 email received in a prior session.
 
-### 2. RDS encrypted-storage migration (~30-60 min downtime)
-The live RDS instance `kjyxgeldpfef` is unencrypted. Full runbook in `docs/PRE_LAUNCH_INFRA_CHECKLIST.md` section A:
-1. Snapshot → copy with encryption → restore → update `DATABASE_URL` secret → restart ECS → delete old instance
-2. Then uncomment `storage_encrypted=True` in `infra/stacks/database.py` and re-run `cdk deploy`
+### ~~2. RDS encrypted-storage migration~~ ✅ shipped 2026-04-23 (PR #268)
+Live instance is `listingjet-postgres-encrypted` (StorageEncrypted=True,
+restored 2026-04-17 from an encrypted snapshot of the original
+`kjyxgeldpfef`, which has been deleted). CDK was reconciled via the
+zombie-resource path (PR #268) — the old `Postgres9DC8BB04` logical id
+is a CFN zombie, and a parallel `PostgresEncrypted` construct adopts
+the live instance via `cdk import`. See the header docstring of
+`infra/stacks/database.py` for the rationale and the don't-mutate-the-
+zombies rule.
 
 ### 3. Pre-launch infra revert
 See `docs/PRE_LAUNCH_INFRA_CHECKLIST.md` — infra was deliberately undersized while there are zero users. Before real users land, apply in `infra/stacks/database.py`:


### PR DESCRIPTION
## Summary

CLAUDE.md still listed RDS encryption as an outstanding P0 with a runbook ("snapshot → copy with encryption → restore → uncomment storage_encrypted=True"). That work shipped on 2026-04-23 via PR #268 (zombie-resource path) — the live instance `listingjet-postgres-encrypted` was restored from an encrypted snapshot on 2026-04-17 and CDK was reconciled by importing it as a parallel `PostgresEncrypted` construct.

The header docstring of `infra/stacks/database.py` already documents the actual end-state and the don't-mutate-the-zombies rule. This PR points CLAUDE.md at that file instead of leaving the stale instructions to mislead the next session.

## Test plan

- [x] `infra/stacks/database.py` confirmed: live instance is `listingjet-postgres-encrypted` (StorageEncrypted=True), `Postgres9DC8BB04` is a CFN zombie, parallel `PostgresEncrypted` construct adopts the live resource via cdk import.
- [x] `git log` confirms PR #268 (commit `6b27401`) and PR #269 docs handoff are landed on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)