### PR TITLE
docs: strike resolved items from MASTER_TODO + TODO

### DIFF
--- a/MASTER_TODO.md
+++ b/MASTER_TODO.md
@@ -28,8 +28,8 @@ Compiled from: `TODO.md`, `PRE_LAUNCH_AUDIT.md`, `ADMIN_DASHBOARD_PROGRESS.md`, 
 - [x] **Separate dev/prod S3 buckets** — cutover deployed 2026-04-16. Live bucket is `listingjet-media-265911026550-us-east-1`; old `listingjet-dev` (913 objects / ~3 GB of pre-launch test data) and empty `listingjet-prod` were deleted post-deploy. Local-dev fallback landmine (`s3_bucket_name = "listingjet-dev"` default in `src/listingjet/config/__init__.py`) has since been defused — the default is now `""`, so a missing env var fails loudly instead of silently writing to a deleted bucket.
 - [x] **Rename CloudWatch log groups** from `/launchlens/*` to `/listingjet/*` — deployed 2026-04-16. Old `/launchlens/*` log groups were replaced on deploy; historical logs under the old names are gone (retention was 30 days so no meaningful loss).
 - [ ] **Pre-launch infra revert** — apply `docs/PRE_LAUNCH_INFRA_CHECKLIST.md` (RDS/Redis/ECS upsizing, Multi-AZ, Container Insights, budget ceiling)
-- [ ] **🚨 RDS encrypted-storage migration** — live DB `kjyxgeldpfef` is unencrypted; must migrate to encrypted instance before real user data lands. One-shot ~30-60 min downtime window. Full cutover plan in `docs/PRE_LAUNCH_INFRA_CHECKLIST.md` (section A).
-- [ ] **🚨 Confirm email provider — SMTP path appears abandoned in favor of Resend.** Verified live state on 2026-04-16: `listingjet/app` has `RESEND_API_KEY` set to a real `re_...` value (36 chars), `EMAIL_ENABLED=true`, and `SMTP_PASSWORD` is **empty string** (not the old `PLACEHOLDER_SMTP_PASSWORD`). Action: audit `src/listingjet/notifications/` for any remaining SMTP callers (if none, drop `SMTP_PASSWORD` from the secret + `.env.example`); otherwise pick one provider and delete the other path. SES production access is still pending (sandbox: 1/sec, 200/day cap).
+- [x] **RDS encrypted-storage migration** — shipped 2026-04-23 via PR #268. Live instance is `listingjet-postgres-encrypted` (StorageEncrypted=True, restored from encrypted snapshot 2026-04-17). CDK reconciled via zombie-resource path; see header docstring of `infra/stacks/database.py` for the don't-mutate-the-zombies rule.
+- [x] **Confirm email provider — Resend is the active path.** Resend SMTP wiring (PR #261) is live and verified in prod (real Resend email received). SES production access still pending but no longer a blocker — Resend handles transactional mail.
 
 ### Post-Apr-14 Infra Followups (from the drift-fix + #226 deploy session)
 - (RDS encryption migration — see the P0 entry above; same item, single source of truth.)
@@ -69,9 +69,9 @@ After the cost-optimization branch is deployed and has run for **at least 7 days
 - [x] **Dual credit systems (Audit #8)** — Dropped `Tenant.credit_balance`; `CreditAccount` is sole source of truth (migration 046)
 
 ### Deployment
-- [ ] **Deploy backend with new analytics endpoints** (ECR push + ECS redeploy)
-- [ ] **Test analytics page on production**
-- [ ] **Merge PR #109** once CI passes
+- [x] **Deploy backend with new analytics endpoints** — shipped via PR #109 (merged 2026-04-02) and rolled to prod via deploy.yml.
+- [x] **Test analytics page on production** — shipped with PR #109; redesigned in PR #270 to use `apiClient.getPerformanceOverview()`.
+- [x] **Merge PR #109** — merged 2026-04-02.
 
 ### Vision Pipeline
 - [x] **Add per-image logging** — already logging before/after each T1 and T2 analysis with asset ID and proxy status

--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,10 @@
 # ListingJet — Deferred Items
 
-Items from the code quality audit and UX audit that need design decisions, larger refactors, or are low priority.
+Items needing design decisions or pending verification.
+
+> **Note:** Code-quality audit items (#8, #11, #12, #13, #16, #17, #18, #19, #20, #22) that previously lived under "Needs Larger Refactor" and "Low Priority Cleanup" have all been resolved. See the `[x]` entries under MASTER_TODO P3 ("Code Cleanup (from TODO.md)") for the receipts.
 
 ## Needs Design Decision
-
-- **Dual credit systems (Audit #8):** `CreditAccount` table vs `Tenant.credit_balance` — two sources of truth for credit balance. Need product decision on which is canonical. `CreditService` uses `CreditAccount`; admin API uses `Tenant.credit_balance`. Risk: balances diverge.
 
 - **Nav grouping (UX W001):** Authenticated nav has 8+ top-level links with no hierarchy. Group into primary (Dashboard, Listings) and secondary/utility (Analytics, Billing, Settings, Support, Changelog) with a separator, or move Help items into a dropdown. Need design call on which items are primary.
 
@@ -16,31 +16,9 @@ Items from the code quality audit and UX audit that need design decisions, large
 
 - **Social post hub entry point (UX S006):** Social workflow is accessible from the listing detail page AND via a separate route. Labeling and primary entry point need a decision.
 
-## Needs Larger Refactor
-
-- **Listings.py monolith (Audit #11):** 800+ line single file with 19 endpoints and scattered inline imports. Should split into sub-routers (listings CRUD, review, export, video, package). Risky mid-session — needs careful route migration.
-
-- **CSP blocks frontend (Audit #13):** `SecurityHeadersMiddleware` sets `Content-Security-Policy: default-src 'self'` which blocks inline styles, external fonts, CDN scripts, and Three.js WebGL. Needs frontend audit to determine correct CSP directives (at minimum `style-src 'unsafe-inline'`, likely `script-src` and `connect-src` adjustments for Three.js, API calls, and Stripe.js).
-
-- **Pipeline status endpoint expensive (Audit #17):** `get_pipeline_status` runs `predict_engagement()` and `extract_features()` on every request, computing over all vision results. Needs caching strategy — either compute once during pipeline execution and store on the listing, or add Redis caching with TTL.
-
 ## Low Priority Cleanup
 
-- **Dead comment in listings.py (Audit #18):** `# Duplicate retry endpoint removed — use the one at line ~616` at end of file.
-
-- **Unused listing states (Audit #19):** `SHADOW_REVIEW`, `GENERATING`, `DELIVERING`, `TRACKING` don't appear in transition logic. Should audit and remove or document intended use.
-
-- **Test JWT fixture doesn't create User rows (Audit #20):** `make_jwt` generates `"sub": f"user-{tenant_id}"` — not a real UUID, no corresponding User row. Tests that go through `get_current_user` would fail. Suggests some endpoints aren't tested through full auth stack.
-
-- **upload-urls endpoint uses `body: dict` (Audit #12 partial):** No Pydantic schema, no OpenAPI docs for request body, no input validation beyond manual key access.
-
-- **Cancel listing reuses FAILED state (Audit #16):** Response returns `"state": "cancelled"` but `ListingState` has no `CANCELLED` value. Should add `CANCELLED` enum value or honestly return `"failed"`.
-
-- **Brand Kit migration gap (Audit #22):** `brand_kit.py` model referenced in migration 011 but migration numbering/chain should be verified.
-
-- **CMA / microsite silent `.catch` on listing detail (UX W004):** `listings/[id]/page.tsx:64-65` swallows errors on initial prefetch via `.catch(() => {})`. Low priority because the fallback \"Generate\" button resurfaces the same error on retry, but could be made explicit if a user-visible failure indicator is desired.
-
-- **Error boundary dashboard link (UX C004):** Mostly shipped in PR #207, but the audit's concern about \"no recovery path\" was inaccurate — the Try Again button already existed. The dashboard link was a 3-line addition. No further action needed unless specific pages want their own fallback.
+- **CMA / microsite silent `.catch` on listing detail (UX W004):** `listings/[id]/page.tsx:64-65` swallows errors on initial prefetch via `.catch(() => {})`. Low priority because the fallback "Generate" button resurfaces the same error on retry, but could be made explicit if a user-visible failure indicator is desired.
 
 ## Pending Verification
 


### PR DESCRIPTION
## Summary

Companion to PR #272. Strikes the same staleness from `MASTER_TODO.md` and `TODO.md`:

**MASTER_TODO.md (5 items resolved):**
- P0 RDS encrypted-storage migration → shipped 2026-04-23 (PR #268)
- P0 Email provider confirmation → Resend live in prod (PR #261, verified by real email)
- P1 Deploy backend with new analytics endpoints → shipped via PR #109 (merged 2026-04-02)
- P1 Test analytics page on production → shipped + redesigned in PR #270
- P1 Merge PR #109 → merged 2026-04-02

**TODO.md (full rewrite):**
- Removed entire "Low Priority Cleanup" and "Needs Larger Refactor" sections whose code-audit items (#8, #11, #12, #13, #16, #17, #18, #19, #20, #22) are already marked `[x]` in MASTER_TODO P3.
- Added a header note pointing to MASTER_TODO P3 for the receipts.
- Kept the genuinely-pending sections: Needs Design Decision, Pending Verification, Housekeeping (and one stray Low Priority Cleanup item that's still real).

After this lands, both files reflect actual current state instead of months-old assumptions.

## Test plan

- [x] PR #109 verified merged 2026-04-02 via `gh pr view 109`
- [x] RDS encryption shipped state verified in PR #272 against `infra/stacks/database.py` header docstring
- [x] Resend confirmation provided by user (received real Resend email last session)
- [x] All audit items struck were already marked `[x]` in MASTER_TODO P3

🤖 Generated with [Claude Code](https://claude.com/claude-code)