### PR TITLE
fix(retry+ui): retry actually restarts stuck workflows; lazy-load gallery

### DIFF
--- a/frontend/src/app/listings/[id]/page.tsx
+++ b/frontend/src/app/listings/[id]/page.tsx
@@ -284,6 +284,8 @@ function ListingDetail() {
                           src={a.thumbnail_url}
                           alt={a.file_path.split("/").pop() || "Photo"}
                           className="w-full h-full object-cover"
+                          loading="lazy"
+                          decoding="async"
                         />
                       ) : (
                         <svg className="w-6 h-6 text-slate-200" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -305,6 +307,8 @@ function ListingDetail() {
                           src={a.thumbnail_url}
                           alt={a.file_path.split('/').pop() || 'Photo'}
                           className="w-full h-full object-cover"
+                          loading="lazy"
+                          decoding="async"
                         />
                       ) : (
                         <div className="w-full h-full flex items-center justify-center">

--- a/src/listingjet/api/listings_workflow.py
+++ b/src/listingjet/api/listings_workflow.py
@@ -249,6 +249,7 @@ async def retry_pipeline(
             listing_id=str(listing.id),
             tenant_id=str(current_user.tenant_id),
             plan=tenant.plan if tenant else "starter",
+            terminate_existing=True,
         )
     except Exception:
         logger.exception("Pipeline retry trigger failed for listing %s", listing.id)

--- a/src/listingjet/temporal_client.py
+++ b/src/listingjet/temporal_client.py
@@ -26,9 +26,22 @@ class TemporalClient:
         plan: str = "starter",
         billing_model: str = "legacy",
         enabled_addons: list[str] | None = None,
+        terminate_existing: bool = False,
     ) -> str:
+        """Start the listing pipeline workflow.
+
+        ``terminate_existing=True`` is for retry: if an old workflow with the
+        same ID is still running (stuck/stalled) it is terminated and a new
+        one takes the slot. Without this, ``REJECT_DUPLICATE`` causes
+        "already started" to be swallowed and the retry silently no-ops.
+        """
         client = await self._connect()
         workflow_id = f"listing-pipeline-{listing_id}"
+        reuse_policy = (
+            WorkflowIDReusePolicy.TERMINATE_IF_RUNNING
+            if terminate_existing
+            else WorkflowIDReusePolicy.REJECT_DUPLICATE
+        )
         try:
             handle = await client.start_workflow(
                 ListingPipeline.run,
@@ -41,11 +54,11 @@ class TemporalClient:
                 ),
                 id=workflow_id,
                 task_queue=settings.temporal_task_queue,
-                id_reuse_policy=WorkflowIDReusePolicy.REJECT_DUPLICATE,
+                id_reuse_policy=reuse_policy,
             )
             return handle.id
         except RPCError as exc:
-            if "already started" in str(exc).lower():
+            if not terminate_existing and "already started" in str(exc).lower():
                 logger.warning(
                     "Workflow already running for listing %s, returning existing handle",
                     listing_id,

--- a/tests/test_temporal_client.py
+++ b/tests/test_temporal_client.py
@@ -1,0 +1,44 @@
+"""Unit tests for TemporalClient.start_pipeline.
+
+Pinning the id_reuse_policy guards the retry-pipeline path: if it ever silently
+flips back to REJECT_DUPLICATE, retries on stuck listings will no-op and the
+"Stalled" UI will be unfixable from the front-end.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from temporalio.common import WorkflowIDReusePolicy
+
+from listingjet.temporal_client import TemporalClient
+
+
+def _make_client_mock() -> MagicMock:
+    """Build an awaitable Client mock whose start_workflow records its kwargs."""
+    fake_handle = MagicMock()
+    fake_handle.id = "listing-pipeline-abc"
+    client = MagicMock()
+    client.start_workflow = AsyncMock(return_value=fake_handle)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_start_pipeline_default_uses_reject_duplicate():
+    tc = TemporalClient()
+    client = _make_client_mock()
+    with patch.object(tc, "_connect", AsyncMock(return_value=client)):
+        await tc.start_pipeline(listing_id="abc", tenant_id="t1")
+    kwargs = client.start_workflow.await_args.kwargs
+    assert kwargs["id_reuse_policy"] == WorkflowIDReusePolicy.REJECT_DUPLICATE
+    assert kwargs["id"] == "listing-pipeline-abc"
+
+
+@pytest.mark.asyncio
+async def test_start_pipeline_retry_uses_terminate_if_running():
+    """terminate_existing=True must pick TERMINATE_IF_RUNNING — the whole
+    point of this flag is to free a stuck workflow ID so retries actually run."""
+    tc = TemporalClient()
+    client = _make_client_mock()
+    with patch.object(tc, "_connect", AsyncMock(return_value=client)):
+        await tc.start_pipeline(listing_id="abc", tenant_id="t1", terminate_existing=True)
+    kwargs = client.start_workflow.await_args.kwargs
+    assert kwargs["id_reuse_policy"] == WorkflowIDReusePolicy.TERMINATE_IF_RUNNING


### PR DESCRIPTION
## Summary

Two related papercuts surfaced while debugging a listing stuck in `UPLOADING`:

1. **Retry was a silent no-op for stalled listings.** `start_pipeline` used `id_reuse_policy=REJECT_DUPLICATE` with a stable workflow id (`listing-pipeline-{listing_id}`). When the user clicked Retry, Temporal raised \"Workflow already started\"; the catch swallowed it, returned the old handle id, and no new workflow ran. State stayed `UPLOADING`, the \"Stalled\" banner reappeared, retry felt broken.
2. **Listing detail loaded ~100 thumbnails up-front.** Gallery `<img>` tags lacked `loading=\"lazy\"`, so every photo started loading on mount. With browser 6-conn-per-origin limits, most stayed queued and got cancelled when re-renders re-issued presigned URLs.

## Fix

- `temporal_client.py`: `start_pipeline` takes a `terminate_existing` flag; when true, picks `WorkflowIDReusePolicy.TERMINATE_IF_RUNNING` so a stuck workflow gets terminated and the id frees for the new run.
- `api/listings_workflow.py`: retry endpoint passes `terminate_existing=True`.
- Initial-upload path keeps `REJECT_DUPLICATE` — accidental dupes still blocked.
- `frontend/src/app/listings/[id]/page.tsx`: adds `loading=\"lazy\"` + `decoding=\"async\"` to both gallery `<img>` tags (grid + list views).

## Test plan

- [x] `pytest tests/test_temporal_client.py tests/test_api/test_listings.py` — 4/4 pass; new tests pin the reuse policy for both default and retry paths so this regression can't sneak back in.
- [x] `tsc --noEmit` clean on the frontend.
- [ ] Post-deploy: click Retry on the listing currently stuck in UPLOADING — confirm state moves past UPLOADING (Temporal worker should pick up the new workflow run).
- [ ] Post-deploy: open a listing with many photos, watch Network → most thumbnails should be deferred until scrolled into view; cancellations should drop sharply.

## Risk

Touches one well-trodden path (retry) and adds two HTML attributes (`loading`/`decoding`). The default `start_pipeline` behavior is unchanged. If TERMINATE_IF_RUNNING ever misbehaves on a healthy long-running pipeline, retry would restart it — but retry is gated on `state ∈ {FAILED, PIPELINE_TIMEOUT, UPLOADING, ANALYZING}`, so it's already opt-in for stuck or broken listings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)