### PR TITLE
fix(reorder): swap photo positions through NULL to dodge unique constraint

### DIFF
--- a/src/listingjet/api/listings_media.py
+++ b/src/listingjet/api/listings_media.py
@@ -310,8 +310,19 @@ async def reorder_package(
         if not sel_from or not sel_to:
             continue
 
-        # Swap positions
-        sel_from.position, sel_to.position = sel_to.position, sel_from.position
+        # Swap positions through a NULL stop. Direct swap violates the
+        # uq_package_selections_listing_channel_position unique constraint
+        # mid-flush (Postgres checks per row, not per statement). NULLs are
+        # treated as distinct by the constraint, so parking sel_from at NULL
+        # frees its position for sel_to before sel_from claims its target.
+        original_from_pos = sel_from.position
+        original_to_pos = sel_to.position
+        sel_from.position = None
+        await db.flush()
+        sel_to.position = original_from_pos
+        await db.flush()
+        sel_from.position = original_to_pos
+        await db.flush()
         sel_from.selected_by = "human"
         sel_to.selected_by = "human"
 

--- a/tests/test_api/test_listings.py
+++ b/tests/test_api/test_listings.py
@@ -251,3 +251,56 @@ async def test_retry_failed_listing(async_client: AsyncClient, db_session):
     assert resp.status_code == 200
     body = resp.json()
     assert body["state"] == "uploading"
+
+
+@pytest.mark.asyncio
+async def test_reorder_package_swaps_positions(async_client: AsyncClient, db_session):
+    """Reorder swap must succeed despite the unique(listing_id, channel, position)
+    constraint. Direct in-place swap violated it mid-flush; the staged-via-NULL
+    fix must produce a clean final state with positions exchanged."""
+    from listingjet.models.listing import Listing
+    from listingjet.models.package_selection import PackageSelection
+
+    token, tenant_id = await _register(async_client)
+    create_resp = await async_client.post("/listings", json={
+        "address": {"street": "Reorder St"}, "metadata": {},
+    }, headers=_auth(token))
+    listing_id = create_resp.json()["id"]
+    listing_uuid = uuid.UUID(listing_id)
+    tenant_uuid = uuid.UUID(tenant_id)
+
+    listing = await db_session.get(Listing, listing_uuid)
+    listing.state = ListingState.AWAITING_REVIEW
+
+    asset_a, asset_b = uuid.uuid4(), uuid.uuid4()
+    db_session.add_all([
+        PackageSelection(
+            id=uuid.uuid4(), tenant_id=tenant_uuid, listing_id=listing_uuid,
+            asset_id=asset_a, channel="mls", position=0, selected_by="ai",
+            composite_score=0.9,
+        ),
+        PackageSelection(
+            id=uuid.uuid4(), tenant_id=tenant_uuid, listing_id=listing_uuid,
+            asset_id=asset_b, channel="mls", position=1, selected_by="ai",
+            composite_score=0.8,
+        ),
+    ])
+    await db_session.commit()
+
+    resp = await async_client.post(
+        f"/listings/{listing_id}/package/reorder",
+        json={"swaps": [{"from_position": 0, "to_position": 1}]},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["swaps_applied"] == 1
+
+    await db_session.commit()  # drop any cached state
+    rows = (await db_session.execute(
+        PackageSelection.__table__.select().where(
+            PackageSelection.listing_id == listing_uuid
+        )
+    )).all()
+    by_asset = {r.asset_id: r.position for r in rows}
+    assert by_asset[asset_a] == 1
+    assert by_asset[asset_b] == 0


### PR DESCRIPTION
## Summary

`POST /listings/{id}/package/reorder` returned **500 Internal Server Error** every time you dragged a photo in the review UI. Production trigger: clicking a swap on a listing in `awaiting_review`.

## Root cause

`src/listingjet/api/listings_media.py:314` did the swap in-place:

```python
sel_from.position, sel_to.position = sel_to.position, sel_from.position
```

The next autoflush (triggered by the `emit_event` call inside the loop, or the final commit) issued two UPDATEs in PK order. The table has `UniqueConstraint(\"listing_id\", \"channel\", \"position\", name=\"uq_package_selections_listing_channel_position\")` — Postgres checks per row, not per statement, so as soon as one row tried to claim the other's not-yet-moved position the constraint fired and the whole transaction rolled back. The frontend showed \"Failed to reorder photos\".

## Fix

Stage one selection at `position=NULL` first (the column is nullable, and Postgres treats NULLs as distinct in unique constraints), flush, write the second to its target, flush, then write the first to its target. Three flushes per swap, no schema change.

## Test plan

- [x] New integration test `test_reorder_package_swaps_positions` inserts two real `PackageSelection` rows, hits the endpoint, and asserts the positions actually swapped. Without the fix this test 500s on the constraint violation.
- [x] `pytest tests/test_api/test_listings.py` — 18/18 pass.
- [ ] Post-deploy: drag a photo in the review UI on the unstuck listing; confirm 200 and the order updates.

## Risk

Three small `await db.flush()` calls in a loop. The end-of-request commit still happens once, so semantics are unchanged. If a swap fails midway, the half-applied state would leave one row at `position=NULL` — but the FastAPI request-level transaction rolls back on any unhandled exception, so this is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)