### PR TITLE
fix(review): tolerate 409 from startReview when approving from queue

### DIFF
--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -314,7 +314,15 @@ function ReviewQueue() {
   async function handleApprove(id: string) {
     setActionLoading(id);
     try {
-      await apiClient.startReview(id);
+      // startReview is a best-effort transition: if the listing is already
+      // IN_REVIEW (e.g. user opened the detail page first), the endpoint
+      // returns 409 — that's fine, we still want to approve.
+      try {
+        await apiClient.startReview(id);
+      } catch (err: unknown) {
+        const status = (err as { status?: number })?.status;
+        if (status !== 409) throw err;
+      }
       await apiClient.approveListing(id);
       setListings((prev) => prev.filter((l) => l.id !== id));
       toast("Listing approved", "success");


### PR DESCRIPTION
## Summary

Approving a listing from the `/review` queue failed with \"Failed to approve\" toast and a `POST /api/listings/{id}/review 409` in the network panel — but **only** when the listing had already been opened on the detail page first.

## Root cause

`frontend/src/app/review/page.tsx:317-318`:

```js
await apiClient.startReview(id);   // 409 if already IN_REVIEW
await apiClient.approveListing(id);
```

\`handleApprove\` unconditionally calls \`startReview\` first to cover the path where the user approves without ever opening the listing detail. If the listing is already \`IN_REVIEW\` (because the detail page transitioned it), \`startReview\` returns 409, the outer catch fires, \`approveListing\` never runs, user is stuck.

## Fix

Wrap \`startReview\` in a nested try/catch that swallows status===409 and proceeds. Other errors (network, 401, 500) still bubble up to the outer catch.

## Test plan

- [x] \`tsc --noEmit\` clean.
- [ ] Open a listing detail page (transitions to IN_REVIEW), navigate to /review queue, click Approve — should succeed.
- [ ] Approve directly from /review queue without opening detail (state still AWAITING_REVIEW) — should still succeed via the original startReview→approveListing path.

## Risk

Frontend-only. Auto-deploys via Vercel (no AWS rollover wait). Backend behavior unchanged — only the client's reaction to a 409 from startReview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)