### PR TITLE
fix(pipeline): tolerate run_chapters and run_social_cuts failures

### DIFF
--- a/src/listingjet/workflows/listing_pipeline.py
+++ b/src/listingjet/workflows/listing_pipeline.py
@@ -213,17 +213,27 @@ class ListingPipeline:
             brand_result = {}
         flyer_key = brand_result.get("flyer_s3_key") if isinstance(brand_result, dict) else None
 
-        # Video post-processing (chapters + social cuts)
-        await workflow.execute_activity(
-            run_chapters, ctx,
-            start_to_close_timeout=_DEFAULT_TIMEOUT,
-            retry_policy=_DEFAULT_RETRY,
-        )
-        await workflow.execute_activity(
-            run_social_cuts, ctx,
-            start_to_close_timeout=_DEFAULT_TIMEOUT,
-            retry_policy=_DEFAULT_RETRY,
-        )
+        # Video post-processing (chapters + social cuts) — tolerated.
+        # These call out to LLMs that occasionally return empty / non-JSON
+        # content; without tolerance one bad completion kills the whole
+        # pipeline before MLS export ever runs. Brand follows the same
+        # pattern just above.
+        try:
+            await workflow.execute_activity(
+                run_chapters, ctx,
+                start_to_close_timeout=_DEFAULT_TIMEOUT,
+                retry_policy=_DEFAULT_RETRY,
+            )
+        except BaseException as exc:
+            workflow.logger.warning("chapters_failed listing=%s error=%s", input.listing_id, exc)
+        try:
+            await workflow.execute_activity(
+                run_social_cuts, ctx,
+                start_to_close_timeout=_DEFAULT_TIMEOUT,
+                retry_policy=_DEFAULT_RETRY,
+            )
+        except BaseException as exc:
+            workflow.logger.warning("social_cuts_failed listing=%s error=%s", input.listing_id, exc)
 
         # Step 3: MLS Export (builds both bundles)
         await workflow.execute_activity(


### PR DESCRIPTION
## Summary

Listing pipeline failed before reaching MLS export when the LLM behind \`run_chapters\` (or \`run_social_cuts\`) returned an empty/non-JSON completion. Listings got stuck post-approval, never reached DELIVERED.

## Root cause

Both activities call into agents that do:

\`\`\`python
data = json.loads(strip_markdown_fences(raw))
\`\`\`

with no fallback. When the model returns empty content, the agent raises \`JSONDecodeError: Expecting value: line 1 column 1 (char 0)\`, Temporal retries 3x, then the activity fails. Both calls are awaited directly in the workflow (lines 217-226), so the failure propagates and kills the whole pipeline before MLS export can run.

Worker logs from the stuck listing (\`10c092ed-…\`):

\`\`\`
Completing activity as failed (run_chapters, attempt 1)
Completing activity as failed (run_chapters, attempt 2)
Completing activity as failed (run_chapters, attempt 3)
\`\`\`

Brand has the exact same vulnerability but is wrapped in \`asyncio.gather(return_exceptions=True)\` and explicitly tolerated (line 211-213). Chapters and social cuts were not.

## Fix

Wrap each \`execute_activity\` in try/except, log a warning, continue. Same shape as the existing \`brand_failed\` warning. These are non-critical content deliverables; the workflow should not block listing delivery on them.

## Test plan

- [x] \`pytest -k 'pipeline or workflow'\` — 30/30 pass.
- [ ] Post-deploy: approve the stuck listing — workflow should advance through chapters/cuts (failing silently if LLM still returns empty), reach MLS export, and finish in DELIVERED.

## Followup (not in this PR)

The \`json.loads(strip_markdown_fences(raw))\` pattern lives in 6 agents — content, floorplan, chapter, social_content, photo_compliance. A shared \`parse_llm_json\` helper that handles empty responses + extracts JSON from prose would fix the root cause across the board. Worth a separate PR once we've shipped delivery.

## Risk

Loosens the workflow's failure semantics for two non-critical activities. If chapters/cuts silently fail, the user gets a delivered listing without those deliverables — surfaced in the warning logs, not the UI. Better than no delivery at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)