### PR TITLE
fix(retry): allow retry from post-approval stuck states

### DIFF
--- a/frontend/src/app/listings/[id]/page.tsx
+++ b/frontend/src/app/listings/[id]/page.tsx
@@ -379,26 +379,30 @@ function ListingDetail() {
             )}
 
             {/* Error / Retry State */}
-            {["failed", "pipeline_timeout", "uploading", "analyzing"].includes(listing.state) && (
+            {["failed", "pipeline_timeout", "uploading", "analyzing", "approved", "exporting"].includes(listing.state) && (
               <div className={`rounded-2xl p-5 ${
-                ["uploading", "analyzing"].includes(listing.state)
+                ["uploading", "analyzing", "approved", "exporting"].includes(listing.state)
                   ? "bg-amber-50 border border-amber-200"
                   : "bg-red-50 border border-red-200"
               }`}>
                 <h4 className={`font-semibold mb-1 ${
-                  ["uploading", "analyzing"].includes(listing.state) ? "text-amber-800" : "text-red-800"
+                  ["uploading", "analyzing", "approved", "exporting"].includes(listing.state) ? "text-amber-800" : "text-red-800"
                 }`}>
                   {["uploading", "analyzing"].includes(listing.state)
                     ? "Processing Stalled"
+                    : ["approved", "exporting"].includes(listing.state)
+                    ? "Post-Approval Processing Stalled"
                     : "Course Correction Required"}
                 </h4>
                 <p className={`text-sm mb-4 ${
-                  ["uploading", "analyzing"].includes(listing.state) ? "text-amber-600" : "text-red-600"
+                  ["uploading", "analyzing", "approved", "exporting"].includes(listing.state) ? "text-amber-600" : "text-red-600"
                 }`}>
                   {listing.state === "pipeline_timeout"
                     ? "Flight delayed. Processing timed out — this can happen with large photo sets."
                     : ["uploading", "analyzing"].includes(listing.state)
                     ? "This listing appears stuck. Click retry to restart the pipeline."
+                    : ["approved", "exporting"].includes(listing.state)
+                    ? "Approved but the post-approval workflow didn't finish. Click retry to restart from scratch (you'll need to re-review)."
                     : "Turbulence detected. Something went wrong during processing."}
                 </p>
                 <div className="flex gap-3">

--- a/src/listingjet/api/listings_workflow.py
+++ b/src/listingjet/api/listings_workflow.py
@@ -232,11 +232,23 @@ async def retry_pipeline(
     if not listing:
         raise HTTPException(status_code=404, detail="Listing not found")
 
-    retryable = {ListingState.FAILED, ListingState.PIPELINE_TIMEOUT, ListingState.UPLOADING, ListingState.ANALYZING}
+    # Includes post-approval states so a Temporal workflow that died after
+    # the user approved (e.g. an LLM activity blew up before MLS export
+    # could run) can still be restarted without a manual DB poke.
+    retryable = {
+        ListingState.FAILED,
+        ListingState.PIPELINE_TIMEOUT,
+        ListingState.UPLOADING,
+        ListingState.ANALYZING,
+        ListingState.AWAITING_REVIEW,
+        ListingState.IN_REVIEW,
+        ListingState.APPROVED,
+        ListingState.EXPORTING,
+    }
     if listing.state not in retryable:
         raise HTTPException(
             status_code=409,
-            detail=f"Can only retry failed or stuck listings, current state: {listing.state.value}",
+            detail=f"Can only retry stuck or failed listings, current state: {listing.state.value}",
         )
 
     listing.state = ListingState.UPLOADING

--- a/tests/test_api/test_listings.py
+++ b/tests/test_api/test_listings.py
@@ -254,6 +254,28 @@ async def test_retry_failed_listing(async_client: AsyncClient, db_session):
 
 
 @pytest.mark.asyncio
+async def test_retry_approved_listing(async_client: AsyncClient, db_session):
+    """A listing whose post-approval workflow died (e.g. an LLM activity
+    blew up before MLS export) is in APPROVED state. It must be retryable
+    so the user has a way to recover without a manual DB poke."""
+    from listingjet.models.listing import Listing
+
+    token, _ = await _register(async_client)
+    create_resp = await async_client.post("/listings", json={
+        "address": {"street": "Approved-stuck St"}, "metadata": {},
+    }, headers=_auth(token))
+    listing_id = create_resp.json()["id"]
+
+    listing = await db_session.get(Listing, uuid.UUID(listing_id))
+    listing.state = ListingState.APPROVED
+    await db_session.commit()
+
+    resp = await async_client.post(f"/listings/{listing_id}/retry", headers=_auth(token))
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "uploading"
+
+
+@pytest.mark.asyncio
 async def test_reorder_package_swaps_positions(async_client: AsyncClient, db_session):
     """Reorder swap must succeed despite the unique(listing_id, channel, position)
     constraint. Direct in-place swap violated it mid-flush; the staged-via-NULL


### PR DESCRIPTION
## Summary

After approve, if the workflow died in Phase 2 (e.g. an LLM activity blew up before MLS export), the listing stayed in \`APPROVED\` state — but \`APPROVED\` wasn't retryable. \`/retry\` returned 409 and the listing-detail \"Stalled\" banner never showed, so the user had no UI path to restart.

## Fix

- **Backend** (\`api/listings_workflow.py\`): extend the retryable set to include AWAITING_REVIEW, IN_REVIEW, APPROVED, EXPORTING. Combined with #278's \`TERMINATE_IF_RUNNING\`, retry now terminates the dead workflow and starts a fresh run.
- **Frontend** (\`listings/[id]/page.tsx\`): show the retry banner for approved/exporting with copy that flags it's a full restart (\"you'll need to re-review\") — sets expectations that human review work doesn't carry over.

## Tradeoff

Restart from UPLOADING loses any human review work on this listing (photo reorder, etc). A \"resume from approval\" path that preserves the review state would need workflow changes — left as a follow-up. This unblocks the path to DELIVERED without a manual DB poke.

## Test plan

- [x] \`pytest tests/test_api/test_listings.py -k retry\` — 3/3 pass; new \`test_retry_approved_listing\` verifies APPROVED → 200 + state=uploading.
- [x] \`tsc --noEmit\` clean.
- [ ] Post-deploy: navigate to the stuck listing detail page, click Retry on the \"Post-Approval Processing Stalled\" banner, watch the workflow run end-to-end (chapters/cuts now tolerated per #281).

🤖 Generated with [Claude Code](https://claude.com/claude-code)