### PR TITLE
fix(pipeline): tolerate empty/invalid LLM JSON across all agents

### DIFF
--- a/src/listingjet/agents/base.py
+++ b/src/listingjet/agents/base.py
@@ -1,8 +1,10 @@
+import json
 import re
 import uuid
 from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from typing import Any
 
 from listingjet.services.metrics import StepTimer
 from listingjet.telemetry import agent_span
@@ -22,6 +24,28 @@ def strip_markdown_fences(text: str) -> str:
     text = text.strip()
     m = re.search(r"```(?:json)?\s*\n?(.*?)```", text, re.DOTALL)
     return m.group(1).strip() if m else text
+
+
+def parse_llm_json(text: str | None) -> Any:
+    """Parse JSON from an LLM completion, returning None on failure.
+
+    Strips ```json fences before parsing. Tolerates None / empty / whitespace
+    / non-JSON inputs. Use at any agent call site where the LLM may return
+    an empty or malformed completion and the workflow should degrade
+    gracefully instead of crashing.
+    """
+    if not text:
+        return None
+    try:
+        cleaned = strip_markdown_fences(text).strip()
+    except (AttributeError, TypeError):
+        return None
+    if not cleaned:
+        return None
+    try:
+        return json.loads(cleaned)
+    except (json.JSONDecodeError, ValueError):
+        return None
 
 
 @dataclass

--- a/src/listingjet/agents/chapter.py
+++ b/src/listingjet/agents/chapter.py
@@ -1,10 +1,8 @@
 """ChapterAgent — analyzes video keyframes via GPT-4V to generate chapter markers."""
 
-import json
-
 from sqlalchemy import select
 
-from listingjet.agents.base import strip_markdown_fences
+from listingjet.agents.base import parse_llm_json
 from listingjet.database import AsyncSessionLocal
 from listingjet.models.listing import Listing
 from listingjet.models.video_asset import VideoAsset
@@ -71,11 +69,8 @@ class ChapterAgent(BaseAgent):
                     prompt=CHAPTER_EXTRACTION_PROMPT,
                 )
 
-                try:
-                    parsed = json.loads(strip_markdown_fences(raw_response))
-                    chapters = parsed.get("chapters", [])
-                except (json.JSONDecodeError, AttributeError):
-                    chapters = []
+                parsed = parse_llm_json(raw_response) or {}
+                chapters = parsed.get("chapters", []) if isinstance(parsed, dict) else []
 
                 video.chapters = chapters
 

--- a/src/listingjet/agents/content.py
+++ b/src/listingjet/agents/content.py
@@ -1,8 +1,8 @@
-import json
+import logging
 
 from sqlalchemy import select
 
-from listingjet.agents.base import strip_markdown_fences
+from listingjet.agents.base import parse_llm_json
 from listingjet.database import AsyncSessionLocal
 from listingjet.models.asset import Asset
 from listingjet.models.brand_kit import BrandKit
@@ -15,6 +15,8 @@ from listingjet.services.fha_filter import fha_check
 from listingjet.services.pii_filter import sanitize_for_prompt
 
 from .base import AgentContext, BaseAgent
+
+logger = logging.getLogger(__name__)
 
 _LANGUAGE_NAMES = {
     "en": "English", "es": "Spanish", "fr": "French", "de": "German",
@@ -188,7 +190,18 @@ class ContentAgent(BaseAgent):
                     temperature=temperature,
                     system_prompt=system_prompt,
                 )
-                parsed = json.loads(strip_markdown_fences(raw))
+                parsed = parse_llm_json(raw)
+                if not parsed or "mls_safe" not in parsed or "marketing" not in parsed:
+                    logger.warning(
+                        "content parse failed listing=%s — falling back to listing metadata description",
+                        listing_id,
+                    )
+                    fallback = meta.get("description", "") or ""
+                    await self.emit(session, context, "content.fallback", {
+                        "reason": "LLM returned empty or malformed JSON",
+                        "fallback_length": len(fallback),
+                    })
+                    return {"mls_safe": fallback, "marketing": fallback, "fha_passed": False, "language": language}
                 mls_safe = parsed["mls_safe"]
                 marketing = parsed["marketing"]
 
@@ -213,10 +226,16 @@ class ContentAgent(BaseAgent):
                         temperature=max(0.1, temperature - 0.2),  # Lower temp for FHA retry
                         system_prompt=system_prompt,
                     )
-                    parsed = json.loads(strip_markdown_fences(raw))
-                    mls_safe = parsed["mls_safe"]
-                    marketing = parsed["marketing"]
-                    fha_result = fha_check({"mls_safe": mls_safe, "marketing": marketing})
+                    retry_parsed = parse_llm_json(raw)
+                    if retry_parsed and "mls_safe" in retry_parsed and "marketing" in retry_parsed:
+                        mls_safe = retry_parsed["mls_safe"]
+                        marketing = retry_parsed["marketing"]
+                        fha_result = fha_check({"mls_safe": mls_safe, "marketing": marketing})
+                    else:
+                        logger.warning(
+                            "content FHA retry parse failed listing=%s — keeping first attempt",
+                            listing_id,
+                        )
 
                 await self.emit(session, context, "content.completed", {
                     "fha_passed": fha_result.passed,

--- a/src/listingjet/agents/floorplan.py
+++ b/src/listingjet/agents/floorplan.py
@@ -1,10 +1,9 @@
-import json
 import logging
 import uuid
 
 from sqlalchemy import select
 
-from listingjet.agents.base import strip_markdown_fences
+from listingjet.agents.base import parse_llm_json
 from listingjet.database import AsyncSessionLocal
 from listingjet.models.asset import Asset
 from listingjet.models.dollhouse_scene import DollhouseScene
@@ -210,9 +209,8 @@ class FloorplanAgent(BaseAgent):
             )
             return None
 
-        try:
-            parsed = json.loads(strip_markdown_fences(raw))
-        except (json.JSONDecodeError, AttributeError):
+        parsed = parse_llm_json(raw)
+        if not isinstance(parsed, dict):
             logger.warning("floorplan parse failed asset=%s", floorplan_asset.id)
             return None
 

--- a/src/listingjet/agents/photo_compliance.py
+++ b/src/listingjet/agents/photo_compliance.py
@@ -7,12 +7,11 @@ text overlays. Uses GPT-4V via OpenAIVisionProvider.
 Results are stored as compliance events and returned as a per-photo report.
 Non-blocking: flags issues as warnings, does not prevent export.
 """
-import json
 from dataclasses import dataclass
 
 from sqlalchemy import select
 
-from listingjet.agents.base import _safe_heartbeat, strip_markdown_fences
+from listingjet.agents.base import _safe_heartbeat, parse_llm_json
 from listingjet.database import AsyncSessionLocal
 from listingjet.models.asset import Asset
 from listingjet.models.listing import Listing
@@ -69,7 +68,9 @@ class PhotoComplianceAgent(BaseAgent):
         """Analyze a single photo for compliance issues."""
         try:
             raw = await self._vision.analyze_with_prompt(image_url, _COMPLIANCE_PROMPT)
-            data = json.loads(strip_markdown_fences(raw))
+            data = parse_llm_json(raw)
+            if not isinstance(data, dict):
+                raise ValueError("LLM returned empty or non-dict JSON")
             return PhotoComplianceResult(
                 asset_id=asset_id,
                 file_path=file_path,

--- a/src/listingjet/agents/social_content.py
+++ b/src/listingjet/agents/social_content.py
@@ -1,8 +1,9 @@
 import json
+import logging
 
 from sqlalchemy import select
 
-from listingjet.agents.base import strip_markdown_fences
+from listingjet.agents.base import parse_llm_json
 from listingjet.database import AsyncSessionLocal
 from listingjet.models.asset import Asset
 from listingjet.models.listing import Listing
@@ -14,6 +15,8 @@ from listingjet.services.fha_filter import fha_check
 from listingjet.services.pii_filter import sanitize_for_prompt
 
 from .base import AgentContext, BaseAgent
+
+logger = logging.getLogger(__name__)
 
 _PROMPT_TEMPLATE = """\
 Generate social media captions for a real estate listing.
@@ -104,7 +107,16 @@ class SocialContentAgent(BaseAgent):
                 )
 
                 raw = await self._llm_provider.complete(prompt=prompt, context=metadata)
-                data = json.loads(strip_markdown_fences(raw))
+                data = parse_llm_json(raw)
+                if not data or "instagram" not in data or "facebook" not in data:
+                    logger.warning(
+                        "social_content parse failed listing=%s — skipping social content",
+                        listing_id,
+                    )
+                    await self.emit(session, context, "social_content.skipped", {
+                        "reason": "LLM returned empty or malformed JSON",
+                    })
+                    return {"platforms": [], "skipped": True, "reason": "empty_llm_response"}
 
                 # FHA check all captions (handle both hooks and flat format)
                 fha_texts = {}
@@ -122,17 +134,24 @@ class SocialContentAgent(BaseAgent):
                     raw = await self._llm_provider.complete(
                         prompt=prompt + _FHA_RETRY_SUFFIX, context=metadata
                     )
-                    data = json.loads(strip_markdown_fences(raw))
-                    fha_texts = {}
-                    for platform in ("instagram", "facebook"):
-                        hooks = data[platform].get("hooks", [])
-                        if hooks:
-                            for i, hook in enumerate(hooks):
-                                fha_texts[f"{platform}_hook_{i}"] = hook.get("caption", "")
-                        else:
-                            fha_texts[f"{platform}_caption"] = data[platform].get("caption", "")
-                        fha_texts[f"{platform}_cta"] = data[platform].get("cta", "")
-                    fha_result = fha_check(fha_texts)
+                    retry_data = parse_llm_json(raw)
+                    if retry_data and "instagram" in retry_data and "facebook" in retry_data:
+                        data = retry_data
+                        fha_texts = {}
+                        for platform in ("instagram", "facebook"):
+                            hooks = data[platform].get("hooks", [])
+                            if hooks:
+                                for i, hook in enumerate(hooks):
+                                    fha_texts[f"{platform}_hook_{i}"] = hook.get("caption", "")
+                            else:
+                                fha_texts[f"{platform}_caption"] = data[platform].get("caption", "")
+                            fha_texts[f"{platform}_cta"] = data[platform].get("cta", "")
+                        fha_result = fha_check(fha_texts)
+                    else:
+                        logger.warning(
+                            "social_content FHA retry parse failed listing=%s — keeping first attempt",
+                            listing_id,
+                        )
 
                 # Store one SocialContent row per platform
                 # Hooks are stored as JSON array in caption field

--- a/tests/chaos/test_provider_failures.py
+++ b/tests/chaos/test_provider_failures.py
@@ -242,15 +242,21 @@ class TestContentAgentLLMFailure:
             await agent.execute(ctx)
 
     @pytest.mark.asyncio
-    async def test_llm_returns_invalid_json_raises(self):
-        """If the LLM returns garbage instead of JSON, the agent must raise."""
+    async def test_llm_returns_invalid_json_falls_back(self):
+        """If the LLM returns garbage, the agent falls back to listing metadata
+        description rather than crashing the workflow.
+        """
         broken_llm = AsyncMock()
         broken_llm.complete.return_value = "this is not json at all"
 
         listing_id = uuid.uuid4()
         mock_listing = MagicMock()
         mock_listing.id = listing_id
-        mock_listing.metadata_ = {"beds": 3, "baths": 2}
+        mock_listing.metadata_ = {
+            "beds": 3,
+            "baths": 2,
+            "description": "Charming three-bedroom home with a sunny backyard.",
+        }
 
         vr_result = MagicMock()
         vr_result.scalars.return_value.all.return_value = []
@@ -264,8 +270,10 @@ class TestContentAgentLLMFailure:
 
         agent = ContentAgent(llm_provider=broken_llm, session_factory=factory)
 
-        with pytest.raises(Exception):
-            await agent.execute(ctx)
+        result = await agent.execute(ctx)
+        assert result["mls_safe"] == mock_listing.metadata_["description"]
+        assert result["marketing"] == mock_listing.metadata_["description"]
+        assert result["fha_passed"] is False
 
     @pytest.mark.asyncio
     async def test_llm_connection_error_propagates(self):

--- a/tests/test_agents/test_base.py
+++ b/tests/test_agents/test_base.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from listingjet.agents.base import AgentContext, BaseAgent
+from listingjet.agents.base import AgentContext, BaseAgent, parse_llm_json
 
 
 class ConcreteAgent(BaseAgent):
@@ -45,3 +45,42 @@ async def test_agent_name_required():
         class NoNameAgent(BaseAgent):
             async def execute(self, context):
                 pass
+
+
+class TestParseLLMJSON:
+    def test_returns_none_for_none(self):
+        assert parse_llm_json(None) is None
+
+    def test_returns_none_for_empty_string(self):
+        assert parse_llm_json("") is None
+
+    def test_returns_none_for_whitespace(self):
+        assert parse_llm_json("   \n\t  ") is None
+
+    def test_parses_plain_json_object(self):
+        assert parse_llm_json('{"a": 1}') == {"a": 1}
+
+    def test_parses_plain_json_array(self):
+        assert parse_llm_json('[1, 2, 3]') == [1, 2, 3]
+
+    def test_parses_json_with_markdown_fences(self):
+        assert parse_llm_json('```json\n{"a": 1}\n```') == {"a": 1}
+
+    def test_parses_json_with_unlabeled_fences(self):
+        assert parse_llm_json('```\n{"a": 1}\n```') == {"a": 1}
+
+    def test_returns_none_for_empty_fenced_block(self):
+        assert parse_llm_json('```json\n\n```') is None
+
+    def test_returns_none_for_malformed_json(self):
+        assert parse_llm_json('{not valid json}') is None
+
+    def test_returns_none_for_prose(self):
+        assert parse_llm_json("Sorry, I can't help with that.") is None
+
+    def test_returns_none_for_truncated_json(self):
+        assert parse_llm_json('{"a": 1') is None
+
+    def test_handles_non_string_gracefully(self):
+        # Some providers return ints/None when their wrapper degrades.
+        assert parse_llm_json(0) is None  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- Adds shared `parse_llm_json` helper in `agents/base.py` that strips markdown fences and returns `None` on empty/malformed input
- Refactors all 7 call sites that previously called `json.loads(strip_markdown_fences(raw))` directly
- Hardens 4 previously-unwrapped sites (`content.py` x2, `social_content.py` x2) with sensible fallbacks

## Why

PR #281 papered over the empty-LLM crash for `run_chapters` and `run_social_cuts`, but the underlying brittle pattern lived in 5 agents across 7 call sites. While verifying listing `10c092ed-…` end-to-end today, the workflow stalled at `run_social_content` with the exact same `json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)` that #281 was meant to address.

This is the durable fix flagged in the original handoff: a shared helper used everywhere.

## Behavior changes

| Site | Before | After |
|---|---|---|
| `chapter.py:75` | try/except → `chapters=[]` | helper → `chapters=[]` (preserved) |
| `floorplan.py:214` | try/except → `None` | helper → `None` (preserved) |
| `photo_compliance.py:72` | broad try/except → "compliant" fallback | helper + raise → same fallback (preserved) |
| `content.py:191` (main) | unwrapped → activity crashes | helper + fallback to listing-metadata description, emits `content.fallback` |
| `content.py:216` (FHA retry) | unwrapped → activity crashes | helper; on parse failure, keeps first attempt |
| `social_content.py:107` (main) | unwrapped → activity crashes | helper; on parse failure, emits `social_content.skipped` and returns no rows |
| `social_content.py:125` (FHA retry) | unwrapped → activity crashes | helper; on parse failure, keeps first attempt |

## Test plan

- [x] 12 new unit tests for `parse_llm_json` covering None, empty, whitespace, fenced/unfenced JSON, malformed JSON, prose-only, truncated JSON, and non-string inputs
- [x] All 105 existing agent tests pass (`pytest tests/test_agents/`)
- [ ] After merge: re-run listing `10c092ed-…` retry and watch it reach `DELIVERED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)