### PR TITLE
fix(video): heartbeat during long-running activity to prevent cancellation

### DIFF
--- a/src/listingjet/agents/base.py
+++ b/src/listingjet/agents/base.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import re
 import uuid
@@ -17,6 +18,31 @@ def _safe_heartbeat(detail: object) -> None:
         activity.heartbeat(detail)
     except RuntimeError:
         pass  # Not running inside a Temporal activity (e.g. unit tests)
+
+
+@asynccontextmanager
+async def heartbeat_during(interval: float = 60.0, detail: object = "alive"):
+    """Send Temporal heartbeats every `interval` seconds while the wrapped block runs.
+
+    Use to keep long-running activities (LLM polling, video generation, S3
+    uploads) alive against the activity's heartbeat_timeout. Outside a
+    Temporal activity context, _safe_heartbeat no-ops, so this is safe to
+    use in unit tests without mocking Temporal.
+    """
+    async def _loop():
+        while True:
+            _safe_heartbeat(detail)
+            await asyncio.sleep(interval)
+
+    task = asyncio.create_task(_loop())
+    try:
+        yield
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
 
 def strip_markdown_fences(text: str) -> str:

--- a/src/listingjet/agents/video.py
+++ b/src/listingjet/agents/video.py
@@ -31,7 +31,7 @@ from listingjet.services.metrics import record_cost
 from listingjet.services.storage import StorageService
 from listingjet.services.video_stitcher import VideoStitcher
 
-from .base import AgentContext, BaseAgent
+from .base import AgentContext, BaseAgent, heartbeat_during
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +57,10 @@ class VideoAgent(BaseAgent):
         self._semaphore = asyncio.Semaphore(3)  # max 3 concurrent Kling calls
 
     async def execute(self, context: AgentContext) -> dict:
-        async with self.session_scope(context) as (session, listing_id, tenant_id):
+        async with (
+            heartbeat_during(interval=60, detail="video"),
+            self.session_scope(context) as (session, listing_id, tenant_id),
+        ):
                 listing = await session.get(Listing, listing_id)
                 if not listing:
                     raise ValueError(f"Listing {listing_id} not found")

--- a/tests/test_agents/test_base.py
+++ b/tests/test_agents/test_base.py
@@ -1,9 +1,15 @@
 # tests/test_agents/test_base.py
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from listingjet.agents.base import AgentContext, BaseAgent, parse_llm_json
+from listingjet.agents.base import (
+    AgentContext,
+    BaseAgent,
+    heartbeat_during,
+    parse_llm_json,
+)
 
 
 class ConcreteAgent(BaseAgent):
@@ -84,3 +90,38 @@ class TestParseLLMJSON:
     def test_handles_non_string_gracefully(self):
         # Some providers return ints/None when their wrapper degrades.
         assert parse_llm_json(0) is None  # type: ignore[arg-type]
+
+
+class TestHeartbeatDuring:
+    @pytest.mark.asyncio
+    async def test_no_op_outside_temporal_activity(self):
+        """Outside a Temporal activity context, _safe_heartbeat raises
+        RuntimeError internally; the helper must swallow it cleanly."""
+        async with heartbeat_during(interval=0.01, detail="test"):
+            await asyncio.sleep(0.05)
+        # No exception = pass
+
+    @pytest.mark.asyncio
+    async def test_sends_heartbeats_at_interval(self):
+        """When wrapping a long-running block, heartbeats fire periodically."""
+        with patch("listingjet.agents.base._safe_heartbeat") as mock_hb:
+            async with heartbeat_during(interval=0.05, detail="test"):
+                await asyncio.sleep(0.18)
+        # Expect ~3-4 heartbeats over 180ms with 50ms interval.
+        assert mock_hb.call_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_task_cleaned_up_on_exit(self):
+        """The internal heartbeat loop must not leak past the context."""
+        before = len(asyncio.all_tasks())
+        async with heartbeat_during(interval=0.01):
+            assert len(asyncio.all_tasks()) == before + 1
+        await asyncio.sleep(0)  # let cancellation propagate
+        assert len(asyncio.all_tasks()) == before
+
+    @pytest.mark.asyncio
+    async def test_block_exception_propagates(self):
+        """If the wrapped block raises, the exception is not swallowed."""
+        with pytest.raises(ValueError, match="boom"):
+            async with heartbeat_during(interval=0.01):
+                raise ValueError("boom")


### PR DESCRIPTION
## Summary

- Add `heartbeat_during(interval=60)` async context manager in `agents/base.py`
- Wrap `VideoAgent.execute()` with it so Kling polls don't trip the workflow's heartbeat timeout

## Why

While verifying listing \`10c092ed-…\` end-to-end today, \`run_video\` failed with \`asyncio.exceptions.CancelledError\` ~10 minutes after starting. Root cause:

- The workflow declares \`heartbeat_timeout=timedelta(minutes=5)\` for the video activity (\`workflows/listing_pipeline.py:168\`)
- \`VideoAgent.execute()\` never calls \`activity.heartbeat()\`
- \`KlingProvider.poll_task()\` polls for up to 5 minutes per clip with no heartbeat
- After 5 minutes idle, Temporal cancels the activity → CancelledError

\`grep heartbeat src/listingjet/agents/video.py\` returns zero hits.

## Why a context manager (not raw heartbeat calls)

A periodic background heartbeat is more robust than scattering \`activity.heartbeat()\` calls through video.py — we don't have to find and decorate every long-running step. It's also reusable for any other agent with long-running work (floorplan vision, content generation if it ever does multi-pass).

## Behavior

| Context | Behavior |
|---|---|
| Inside a Temporal activity | Heartbeats every 60s while the block runs |
| Outside (unit tests, REPL) | \`_safe_heartbeat\` already no-ops on RuntimeError; heartbeat_during just keeps a sleeping task alive |
| Block raises | Background task is cancelled in finally; exception propagates unchanged |

## Test plan

- [x] 4 new unit tests for \`heartbeat_during\`: no-op outside Temporal, periodic heartbeats during a long block, task cleanup on exit, exception propagation
- [x] All existing video.py unit tests still pass
- [ ] After merge: re-run listing \`10c092ed-…\` — video activity should reach completion without cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)