### PR TITLE
feat: storage backend-agnostic + CloudWatch metrics opt-in (migration phase 1)

### DIFF
--- a/docs/runbooks/r2-cutover.md
+++ b/docs/runbooks/r2-cutover.md
@@ -1,0 +1,153 @@
+# Cloudflare R2 Cutover Runbook
+
+ListingJet's media storage is migrating from **AWS S3** to **Cloudflare R2** as part of [Phase 1 of the Render+Supabase migration](../../.. /.claude/plans/breezy-foraging-karp.md). Code is already cutover-ready (PR #285): `StorageService` uses any S3-compatible endpoint when `S3_ENDPOINT_URL` is set. This runbook is the operational side — provisioning R2, syncing data, flipping env vars, smoke testing, rollback.
+
+**Estimated downtime**: 0. The cutover is read-flip-then-rewrite — old S3 reads stay live until the env var changes, R2 starts serving the moment env var is set on the next deploy.
+
+**Estimated effort**: ~30–45 minutes once you have a Cloudflare account.
+
+---
+
+## Prerequisites
+
+- Cloudflare account (free tier is fine — R2 has 10 GB free + $0 egress)
+- Local AWS CLI logged in to the ListingJet account
+- `rclone` installed (`brew install rclone` / `choco install rclone`) OR willingness to use `aws s3 sync` to a temp local dir + upload script
+- PR #285 merged and deployed (so the code can read `S3_ENDPOINT_URL`)
+
+---
+
+## Steps
+
+### 1. Provision R2 in Cloudflare
+
+In the Cloudflare dashboard:
+
+1. **R2 → Create bucket** — name: `listingjet-media`. Location hint: leave default (auto). Click Create.
+2. **R2 → Manage R2 API Tokens → Create API token**:
+   - Name: `listingjet-prod`
+   - Permissions: **Object Read & Write**
+   - Bucket: `listingjet-media` (scope it down)
+   - TTL: forever (or set a rotation reminder)
+   - Click Create. **Copy the Access Key ID, Secret Access Key, and the S3 endpoint URL.** They're shown once.
+
+The endpoint URL looks like `https://<32-char-hex-account-id>.r2.cloudflarestorage.com`.
+
+### 2. Sync existing S3 contents to R2
+
+Source bucket: `listingjet-media-265911026550-us-east-1` (per `infra/stacks/services.py`). Confirm the exact name:
+
+```bash
+aws s3api list-buckets --query "Buckets[?starts_with(Name, 'listingjet-media')].Name" --output text
+```
+
+Configure rclone with both remotes (one-time):
+
+```bash
+rclone config create aws-s3 s3 provider AWS region us-east-1 access_key_id <AWS_KEY> secret_access_key <AWS_SECRET>
+rclone config create r2 s3 provider Cloudflare region auto endpoint <R2_ENDPOINT_URL> access_key_id <R2_KEY> secret_access_key <R2_SECRET>
+```
+
+Dry-run the sync first to see what'll move and how big it is:
+
+```bash
+rclone sync aws-s3:listingjet-media-265911026550-us-east-1 r2:listingjet-media --dry-run --progress
+```
+
+If the size and file count look right, do it for real:
+
+```bash
+rclone sync aws-s3:listingjet-media-265911026550-us-east-1 r2:listingjet-media --progress
+```
+
+For larger payloads, add `--transfers 16 --checkers 32` to parallelize. R2 has $0 ingress, so no cost worry.
+
+Verify counts match:
+
+```bash
+aws s3 ls s3://listingjet-media-265911026550-us-east-1 --recursive --summarize | tail -3
+rclone size r2:listingjet-media
+```
+
+Total size and object count should be identical (or off by a few from in-flight uploads).
+
+### 3. Flip env vars on the running deploy
+
+Today the app runs on AWS ECS with secrets in Secrets Manager. Add three new keys to the `listingjet/app` secret:
+
+```bash
+aws secretsmanager get-secret-value --secret-id listingjet/app --query SecretString --output text > /tmp/app.json
+# edit /tmp/app.json — add:
+#   "S3_ENDPOINT_URL": "https://<account>.r2.cloudflarestorage.com",
+#   "S3_ACCESS_KEY_ID": "<R2_KEY>",
+#   "S3_SECRET_ACCESS_KEY": "<R2_SECRET>"
+aws secretsmanager put-secret-value --secret-id listingjet/app --secret-string "$(cat /tmp/app.json)"
+rm /tmp/app.json
+```
+
+Force ECS to pick up the new values (running tasks keep the old env until restart):
+
+```bash
+aws ecs update-service --cluster listingjet --service listingjet-api --force-new-deployment
+aws ecs update-service --cluster listingjet --service listingjet-worker --force-new-deployment
+```
+
+Wait for both to roll:
+
+```bash
+aws ecs describe-services --cluster listingjet --services listingjet-api listingjet-worker \
+  --query "services[*].[serviceName,deployments[0].rolloutState]" --output text
+```
+
+Both should report `COMPLETED` (typically 2–3 minutes).
+
+### 4. Smoke test
+
+Through the running app, exercise each of the four `StorageService` operations:
+
+| Operation | How to trigger |
+|---|---|
+| **upload** | Upload a photo via the listing creation wizard (frontend) — completes if the worker can write to R2 |
+| **presigned_url** | Open a listing detail page that displays photos — the gallery loads from presigned R2 URLs |
+| **download** | Trigger any pipeline activity that downloads originals (e.g. retry a workflow) |
+| **delete** | Delete an asset from a listing |
+
+Backend check — tail worker logs for any `StorageError`:
+
+```bash
+MSYS_NO_PATHCONV=1 aws logs filter-log-events --log-group-name '/listingjet/worker' \
+  --start-time $(($(date +%s%3N) - 600000)) --filter-pattern "StorageError" --max-items 10
+```
+
+If empty for 10 minutes after a real listing flow, cutover is healthy.
+
+### 5. Decommission AWS S3 (optional, do later)
+
+**Don't rush this.** Keep the AWS bucket for a week or two as a rollback safety net. Once you're confident R2 is healthy:
+
+```bash
+aws s3 rb s3://listingjet-media-265911026550-us-east-1 --force
+```
+
+When the CDK stack is torn down in Phase 3, the bucket goes with it.
+
+---
+
+## Rollback
+
+The whole cutover is a 3-env-var flip. To revert:
+
+1. Edit `listingjet/app` secret — remove `S3_ENDPOINT_URL`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY` (or set them empty).
+2. `aws ecs update-service ... --force-new-deployment` for both api and worker.
+3. App falls back to default boto3 credential chain → AWS S3 with IAM role.
+
+R2 keeps the data; nothing is destroyed by the rollback. New writes during the R2 window stay in R2 and are not present in S3 (this is a real, but small, consequence — usually <1 hour of writes if rolling back fast).
+
+---
+
+## Common gotchas
+
+- **`region: auto` vs `region: us-east-1`** — R2 wants `auto`. The app reads `aws_region` from `AWS_REGION`. Either set `AWS_REGION=auto` for the R2-using services, OR leave it as `us-east-1` (boto3 sigv4 still works because the signature is computed against the endpoint URL, not the region — but `auto` is the supported config).
+- **Presigned PUT URLs** — used by the photo upload wizard via `generate_presigned_post`. R2 supports this since it's standard S3 sigv4. Test specifically by uploading a photo through the wizard — that's the only call site that uses POST presigning.
+- **CORS on R2 bucket** — if the frontend uploads directly to R2 via presigned URLs (it does), the R2 bucket needs a CORS policy allowing the Vercel origin. In the Cloudflare dashboard: R2 → bucket → Settings → CORS Policy → add an entry allowing `https://listingjet.ai` and the Vercel preview URL pattern with `PUT`, `POST`, `GET` methods.
+- **Public asset URLs** — if any code constructs raw S3 URLs (`https://bucket.s3.region.amazonaws.com/key`), they won't work on R2. Audit before flipping. As of PR #285 all asset URLs go through `presigned_url`, which uses the configured client — safe.

--- a/src/listingjet/config/__init__.py
+++ b/src/listingjet/config/__init__.py
@@ -77,9 +77,17 @@ class Settings(BaseSettings):
     # (invite accept, password reset, etc).
     frontend_url: str = "https://listingjet.ai"
 
-    # S3
+    # S3 / object storage. Set s3_endpoint_url + s3_access_key_id + s3_secret_access_key
+    # to point at an S3-compatible backend (e.g. Cloudflare R2). Empty endpoint URL
+    # means default AWS S3 with the boto3 credential chain (IAM role, env, profile).
     s3_bucket_name: str = ""
     aws_region: str = "us-east-1"
+    s3_endpoint_url: str = ""
+    s3_access_key_id: str = ""
+    s3_secret_access_key: str = ""
+
+    # CloudWatch metrics — opt-in. Set true on AWS deploys; off everywhere else.
+    cloudwatch_enabled: bool = False
 
     # Monitoring
     sentry_dsn: str = ""

--- a/src/listingjet/monitoring/metrics.py
+++ b/src/listingjet/monitoring/metrics.py
@@ -26,8 +26,12 @@ def emit_metric(
     unit: str = "None",
     dimensions: dict[str, str] | None = None,
 ) -> None:
-    """Emit a CloudWatch custom metric. No-op in development."""
+    """Emit a CloudWatch custom metric. No-op in development or when
+    settings.cloudwatch_enabled is False (default for non-AWS environments).
+    """
     if settings.app_env == "development":
+        return
+    if not settings.cloudwatch_enabled:
         return
 
     try:

--- a/src/listingjet/services/storage.py
+++ b/src/listingjet/services/storage.py
@@ -1,6 +1,9 @@
 # src/listingjet/services/storage.py
 """
-S3-backed storage service.
+S3-compatible object storage.
+
+Works with AWS S3 (default) or any S3-compatible backend (e.g. Cloudflare R2)
+when settings.s3_endpoint_url is set.
 
 All asset uploads use a consistent key scheme:
   listings/{listing_id}/{asset_type}/{filename}
@@ -19,14 +22,21 @@ logger = logging.getLogger(__name__)
 
 
 class StorageError(Exception):
-    """Raised when an S3 operation fails."""
+    """Raised when an object storage operation fails."""
 
 
 class StorageService:
     def __init__(self, bucket: str = None, region: str = None):
         self._bucket = bucket or settings.s3_bucket_name
         self._region = region or settings.aws_region
-        self._client = boto3.client("s3", region_name=self._region)
+
+        client_kwargs = {"region_name": self._region}
+        if settings.s3_endpoint_url:
+            client_kwargs["endpoint_url"] = settings.s3_endpoint_url
+        if settings.s3_access_key_id and settings.s3_secret_access_key:
+            client_kwargs["aws_access_key_id"] = settings.s3_access_key_id
+            client_kwargs["aws_secret_access_key"] = settings.s3_secret_access_key
+        self._client = boto3.client("s3", **client_kwargs)
 
     def upload(self, key: str, data: bytes | io.IOBase, content_type: str) -> str:
         """Upload bytes or file-like object. Returns the S3 key."""

--- a/tests/test_monitoring/test_metrics.py
+++ b/tests/test_monitoring/test_metrics.py
@@ -11,6 +11,7 @@ def test_emit_metric_calls_cloudwatch():
     with patch("listingjet.monitoring.metrics._get_cloudwatch_client", return_value=mock_client):
         with patch("listingjet.monitoring.metrics.settings") as mock_settings:
             mock_settings.app_env = "production"
+            mock_settings.cloudwatch_enabled = True
             emit_metric("RequestCount", 1, unit="Count", dimensions={"endpoint": "/health"})
             mock_client.put_metric_data.assert_called_once()
             call_args = mock_client.put_metric_data.call_args[1]
@@ -24,6 +25,19 @@ def test_emit_metric_noop_in_development():
     from listingjet.monitoring.metrics import emit_metric
     with patch("listingjet.monitoring.metrics.settings") as mock_settings:
         mock_settings.app_env = "development"
+        mock_settings.cloudwatch_enabled = True  # even when enabled, dev noops
+        with patch("listingjet.monitoring.metrics._get_cloudwatch_client") as mock_cw:
+            emit_metric("RequestCount", 1)
+            mock_cw.assert_not_called()
+
+
+def test_emit_metric_noop_when_cloudwatch_disabled():
+    """In non-dev environments, cloudwatch_enabled=False (the default for
+    non-AWS deploys) must skip emitting and avoid creating a client."""
+    from listingjet.monitoring.metrics import emit_metric
+    with patch("listingjet.monitoring.metrics.settings") as mock_settings:
+        mock_settings.app_env = "production"
+        mock_settings.cloudwatch_enabled = False
         with patch("listingjet.monitoring.metrics._get_cloudwatch_client") as mock_cw:
             emit_metric("RequestCount", 1)
             mock_cw.assert_not_called()
@@ -35,7 +49,7 @@ async def test_time_metric_decorator():
 
     @time_metric("TestDuration")
     async def slow_function():
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.05)
         return "done"
 
     with patch("listingjet.monitoring.metrics.emit_metric") as mock_emit:
@@ -44,4 +58,5 @@ async def test_time_metric_decorator():
         mock_emit.assert_called_once()
         call_args = mock_emit.call_args
         assert call_args[0][0] == "TestDuration"
-        assert call_args[0][1] >= 10  # at least 10ms
+        # 50ms sleep — assert >=30ms to allow headroom for Windows clock resolution.
+        assert call_args[0][1] >= 30

--- a/tests/test_services/test_storage.py
+++ b/tests/test_services/test_storage.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import boto3
 import pytest
 from moto import mock_aws
@@ -36,3 +38,34 @@ def test_upload_file_like_object(s3_service):
     buf = io.BytesIO(b"image-data")
     key = s3_service.upload(key="listings/abc/photo.jpg", data=buf, content_type="image/jpeg")
     assert key == "listings/abc/photo.jpg"
+
+
+def test_default_aws_client_no_endpoint_url():
+    """Without s3_endpoint_url set, boto3 hits AWS (no custom endpoint)."""
+    with patch("listingjet.services.storage.boto3.client") as mock_client:
+        with patch("listingjet.services.storage.settings") as mock_settings:
+            mock_settings.s3_bucket_name = "default-bucket"
+            mock_settings.aws_region = "us-east-1"
+            mock_settings.s3_endpoint_url = ""
+            mock_settings.s3_access_key_id = ""
+            mock_settings.s3_secret_access_key = ""
+            StorageService()
+            kwargs = mock_client.call_args[1]
+            assert kwargs == {"region_name": "us-east-1"}
+
+
+def test_r2_endpoint_and_creds_passed_to_boto3():
+    """When s3_endpoint_url + creds are set (R2 case), they reach boto3."""
+    with patch("listingjet.services.storage.boto3.client") as mock_client:
+        with patch("listingjet.services.storage.settings") as mock_settings:
+            mock_settings.s3_bucket_name = "media"
+            mock_settings.aws_region = "auto"
+            mock_settings.s3_endpoint_url = "https://acct.r2.cloudflarestorage.com"
+            mock_settings.s3_access_key_id = "AKIA-r2"
+            mock_settings.s3_secret_access_key = "secret-r2"
+            StorageService()
+            kwargs = mock_client.call_args[1]
+            assert kwargs["endpoint_url"] == "https://acct.r2.cloudflarestorage.com"
+            assert kwargs["aws_access_key_id"] == "AKIA-r2"
+            assert kwargs["aws_secret_access_key"] == "secret-r2"
+            assert kwargs["region_name"] == "auto"


### PR DESCRIPTION
## Summary

Phase 1 of the AWS → Render+Supabase migration plan ([plan](https://github.com/jlabella44-cpu/Launchlens/blob/main/.claude/plans/breezy-foraging-karp.md), local copy).

Two small, low-risk code changes that prep the codebase for the move without forcing any infrastructure cutover yet:

1. **`StorageService` is now S3-API-compatible-backend aware** — reads optional `s3_endpoint_url` + `s3_access_key_id` + `s3_secret_access_key` and passes them to `boto3.client("s3")`. Defaults are empty, so existing AWS S3 + IAM-role auth keeps working identically. Lets the same code target Cloudflare R2 (or any S3-compatible backend) by env vars alone.

2. **CloudWatch metrics gated on `cloudwatch_enabled` flag** (default `False`). Existing dev-mode noop preserved on top.

Also fixes a pre-existing Windows-clock-resolution flake in `test_time_metric_decorator` (sleep 10ms → 50ms, threshold 10ms → 30ms).

## ⚠️ Behavior change after deploy

**CloudWatch metrics will stop emitting on the current AWS prod stack** unless `CLOUDWATCH_ENABLED=true` is added to the ECS task environment. This is intentional — metrics (`RequestCount`, `ErrorCount`, `RequestLatency`, `PipelineStageDuration`) are nice-to-have observability and the AWS stack is being retired in Phases 2-3. Sentry handles errors; stdout logs cover the rest.

If you want to preserve metrics on AWS through the migration window, add `CLOUDWATCH_ENABLED=true` to the relevant ECS task definition before merging.

## Files

- \`src/listingjet/config/__init__.py\` — 4 new fields (`s3_endpoint_url`, `s3_access_key_id`, `s3_secret_access_key`, `cloudwatch_enabled`)
- \`src/listingjet/services/storage.py\` — conditional kwargs for `boto3.client`
- \`src/listingjet/monitoring/metrics.py\` — added `cloudwatch_enabled` gate
- \`tests/test_services/test_storage.py\` — 2 new tests for endpoint/creds plumbing
- \`tests/test_monitoring/test_metrics.py\` — 1 new test for noop-when-disabled; sleep/threshold bumped on existing flake

## Test plan

- [x] All 10 storage + metrics tests pass locally
- [x] 8/8 stable runs of the previously-flaky `test_time_metric_decorator`
- [x] 105 agent tests + 452 service/monitoring/agent tests pass on this branch
- [ ] After merge: configure Cloudflare R2 bucket and set `S3_ENDPOINT_URL`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY` in Render env (Phase 1 follow-up — separate cutover task once R2 bucket is provisioned and media synced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)