### PR TITLE
feat(migration): finish moving off AWS → Render + Supabase + R2 + Temporal Cloud

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,28 +1,47 @@
+# Production environment — Render + Supabase + Upstash + Cloudflare R2 + Temporal Cloud
+# (migrated off AWS ECS/RDS/ElastiCache/S3). On Render these live in the
+# `listingjet-shared` env group; see render.yaml and
+# docs/runbooks/render-supabase-cutover.md.
+
 # App
 APP_ENV=production
 LOG_LEVEL=INFO
 GIT_SHA=  # set by CI
+FRONTEND_URL=https://listingjet.ai
+CORS_ORIGINS=https://listingjet.ai
 
-# Database
-DATABASE_URL=postgresql+asyncpg://user:pass@rds-host:5432/launchlens
-DATABASE_URL_SYNC=postgresql://user:pass@rds-host:5432/launchlens
+# Database (Supabase)
+# Point DATABASE_URL at the Supabase transaction pooler (port 6543) and set
+# DB_USE_PGBOUNCER=true so asyncpg disables its prepared-statement cache.
+# DATABASE_URL_SYNC (Alembic) should use the direct connection (port 5432).
+DATABASE_URL=postgresql+asyncpg://postgres.<ref>:<pass>@aws-0-<region>.pooler.supabase.com:6543/postgres
+DATABASE_URL_SYNC=postgresql://postgres.<ref>:<pass>@aws-0-<region>.pooler.supabase.com:5432/postgres
+DB_USE_PGBOUNCER=true
 
 # Auth
 JWT_SECRET=  # generate: python -c "import secrets; print(secrets.token_urlsafe(32))"
+FIELD_ENCRYPTION_KEY=  # python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 
 # Stripe
 STRIPE_SECRET_KEY=sk_live_...
 STRIPE_WEBHOOK_SECRET=whsec_...
 
-# Redis
-REDIS_URL=redis://elasticache-host:6379/0
+# Redis (Upstash — note the rediss:// TLS scheme)
+REDIS_URL=rediss://default:<pass>@<endpoint>.upstash.io:6379
 
-# Temporal
-TEMPORAL_HOST=temporal-host:7233
+# Temporal Cloud (TLS is implied once TEMPORAL_API_KEY is set)
+TEMPORAL_HOST=<namespace>.<account>.tmprl.cloud:7233
+TEMPORAL_NAMESPACE=<namespace>.<account>
+TEMPORAL_API_KEY=...
 
-# S3
-S3_BUCKET_NAME=launchlens-prod
-AWS_REGION=us-east-1
+# Object storage (Cloudflare R2 — S3-compatible)
+S3_BUCKET_NAME=listingjet-media
+S3_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
+S3_ACCESS_KEY_ID=...
+S3_SECRET_ACCESS_KEY=...
+AWS_REGION=auto
+# CloudWatch is AWS-only; leave off everywhere else.
+CLOUDWATCH_ENABLED=false
 
 # Providers
 OPENAI_API_KEY=sk-...
@@ -36,6 +55,11 @@ CANVA_DEFAULT_TEMPLATE_ID=DAG...
 # Video
 KLING_ACCESS_KEY=...
 KLING_SECRET_KEY=...
+ELEVENLABS_API_KEY=...
+
+# Email (Resend)
+EMAIL_ENABLED=true
+RESEND_API_KEY=re_...
 
 # Monitoring
 SENTRY_DSN=https://...@sentry.io/...

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,21 +1,14 @@
-name: Deploy to AWS
+name: Deploy to Render
 
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
-env:
-  AWS_REGION: us-east-1
-  ECR_REPO_API: listingjet-api
-  ECR_REPO_WORKER: listingjet-worker
-  ECS_CLUSTER: listingjet
-  ECS_SERVICE_API: listingjet-api
-  ECS_SERVICE_WORKER: listingjet-worker
-
-permissions:
-  id-token: write
-  contents: read
+# Deploys are gated on the test job. Render is configured with autoDeploy:false
+# (see render.yaml), so nothing ships until tests pass and this workflow fires
+# the per-service deploy hooks. The blueprint's preDeployCommand runs Alembic
+# migrations against the new image and aborts the deploy on a non-zero exit.
 
 jobs:
   test:
@@ -53,108 +46,32 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Login to ECR
-        id: ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Build and push API + Worker image
+      - name: Trigger Render deploy (API)
         env:
-          REGISTRY: ${{ steps.ecr.outputs.registry }}
-          IMAGE_TAG: ${{ github.sha }}
+          HOOK: ${{ secrets.RENDER_DEPLOY_HOOK_API }}
         run: |
-          # API and worker share the Dockerfile; the entrypoint selects
-          # api (uvicorn) vs worker (Temporal) mode by env. Tag the single
-          # build to both ECR repos so the worker service (which pulls from
-          # listingjet-worker:latest per infra/stacks/services.py:274) stays
-          # in sync with main. DeployRole was granted push on worker_repo in
-          # PR #249 + cdk deploy ListingJetServices ListingJetCI.
-          docker build \
-            -t $REGISTRY/$ECR_REPO_API:$IMAGE_TAG \
-            -t $REGISTRY/$ECR_REPO_API:latest \
-            -t $REGISTRY/$ECR_REPO_WORKER:$IMAGE_TAG \
-            -t $REGISTRY/$ECR_REPO_WORKER:latest \
-            .
-          docker push $REGISTRY/$ECR_REPO_API:$IMAGE_TAG
-          docker push $REGISTRY/$ECR_REPO_API:latest
-          docker push $REGISTRY/$ECR_REPO_WORKER:$IMAGE_TAG
-          docker push $REGISTRY/$ECR_REPO_WORKER:latest
-
-      - name: Run database migrations
-        env:
-          REGISTRY: ${{ steps.ecr.outputs.registry }}
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          # Derive network config + task definition + container name from the
-          # running API service. The task def family is CDK-generated
-          # (e.g. ListingJetServicesApiTaskCC6F2D94), so hardcoding the ECR
-          # repo name as the family fails with "TaskDefinition not found".
-          # The container name inside the CDK task def is "api", not the ECR
-          # repo name either.
-          SERVICE_JSON=$(aws ecs describe-services \
-            --cluster $ECS_CLUSTER \
-            --services $ECS_SERVICE_API \
-            --query 'services[0]' \
-            --output json)
-          NETWORK_CONFIG=$(echo "$SERVICE_JSON" | jq -c '.networkConfiguration')
-          TASK_DEF_ARN=$(echo "$SERVICE_JSON" | jq -r '.taskDefinition')
-          # Container name matches the CDK construct in infra/stacks/services.py
-          # (`api_task.add_container("api", ...)`). Hardcoded because the GitHub
-          # deploy role lacks ecs:DescribeTaskDefinition. If the container is ever
-          # renamed in the CDK stack, update this string.
-          CONTAINER_NAME="api"
-
-          echo "Task definition: $TASK_DEF_ARN"
-          echo "Container name:  $CONTAINER_NAME"
-
-          # Run a one-shot Fargate task with CMD=migrate against the current
-          # task definition. The 'migrate' entrypoint exits non-zero on failure,
-          # which propagates here so the deploy is aborted before traffic shifts.
-          OVERRIDES=$(jq -nc \
-            --arg name "$CONTAINER_NAME" \
-            '{containerOverrides: [{name: $name, command: ["migrate"]}]}')
-          TASK_ARN=$(aws ecs run-task \
-            --cluster $ECS_CLUSTER \
-            --task-definition "$TASK_DEF_ARN" \
-            --launch-type FARGATE \
-            --network-configuration "$NETWORK_CONFIG" \
-            --overrides "$OVERRIDES" \
-            --query 'tasks[0].taskArn' \
-            --output text)
-
-          echo "Migration task ARN: $TASK_ARN"
-          echo "Waiting for migration task to complete..."
-          aws ecs wait tasks-stopped --cluster $ECS_CLUSTER --tasks "$TASK_ARN"
-
-          EXIT_CODE=$(aws ecs describe-tasks \
-            --cluster $ECS_CLUSTER \
-            --tasks "$TASK_ARN" \
-            --query 'tasks[0].containers[0].exitCode' \
-            --output text)
-
-          if [ "$EXIT_CODE" != "0" ]; then
-            echo "ERROR: Migration task failed with exit code $EXIT_CODE"
+          if [ -z "$HOOK" ]; then
+            echo "RENDER_DEPLOY_HOOK_API not set — skipping API deploy trigger" >&2
             exit 1
           fi
-          echo "Migrations completed successfully (exit 0)"
+          curl -fsS "$HOOK" && echo "API deploy triggered"
 
-      - name: Deploy API + Worker services
+      - name: Trigger Render deploy (Worker)
+        env:
+          HOOK: ${{ secrets.RENDER_DEPLOY_HOOK_WORKER }}
         run: |
-          aws ecs update-service --cluster $ECS_CLUSTER --service $ECS_SERVICE_API --force-new-deployment
-          aws ecs update-service --cluster $ECS_CLUSTER --service $ECS_SERVICE_WORKER --force-new-deployment
+          if [ -z "$HOOK" ]; then
+            echo "RENDER_DEPLOY_HOOK_WORKER not set — skipping worker deploy trigger" >&2
+            exit 1
+          fi
+          curl -fsS "$HOOK" && echo "Worker deploy triggered"
 
       - name: Notify Sentry
         if: always()
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
+          [ -z "$SENTRY_AUTH_TOKEN" ] && { echo "No Sentry token — skipping"; exit 0; }
           curl -sL https://sentry.io/api/0/organizations/${{ secrets.SENTRY_ORG }}/releases/ \
             -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
             -H "Content-Type: application/json" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 - **Backend:** FastAPI + Temporal + PostgreSQL + Redis, Python 3.12, Alembic migrations
 - **Frontend:** Next.js 16 (App Router), Tailwind CSS v4, TypeScript
-- **Infra:** AWS ECS Fargate + ECR + RDS + ElastiCache + S3, CDK in `infra/`
+- **Infra:** Render (API + worker), Supabase Postgres, Upstash Redis, Cloudflare R2 (media), Temporal Cloud — see `render.yaml`. (Migrated off AWS; the CDK in `infra/` is decommission-only — see `infra/README.md`.)
 - **Tests:** pytest + pytest-cov, vitest for frontend
 
 ---
@@ -152,33 +152,20 @@ All P2/P3 feature work is complete. The full list is in `MASTER_TODO.md`. Notabl
 
 ---
 
-## Remaining P0 items (production blockers)
+## Migration off AWS → Render + Supabase + R2 (in progress)
 
-These all require **external AWS actions** — no code changes needed, just ops work:
+The platform is moving off AWS to **Render** (API + worker), **Supabase**
+(Postgres), **Upstash** (Redis), **Cloudflare R2** (media), and **Temporal
+Cloud**. The **code + config is done**; what remains is operational (provision
+the accounts, sync data, flip DNS, decommission AWS).
 
-### ~~1. Email provider wiring~~ ✅ shipped + verified 2026-04-26
-Resend SMTP wiring (PR #261) is live in prod — confirmed by a real Resend
-email received in a prior session.
+- **Compute / DB / cache / Temporal cutover** → `docs/runbooks/render-supabase-cutover.md`
+- **Storage (S3 → R2) cutover** → `docs/runbooks/r2-cutover.md`
+- **Deploy target** → `render.yaml` (Render blueprint); CI is `.github/workflows/deploy.yml` (test-gated Render deploy hooks).
+- **AWS CDK** in `infra/` is **decommission-only** — used solely for the final `cdk destroy`. See `infra/README.md`.
 
-### ~~2. RDS encrypted-storage migration~~ ✅ shipped 2026-04-23 (PR #268)
-Live instance is `listingjet-postgres-encrypted` (StorageEncrypted=True,
-restored 2026-04-17 from an encrypted snapshot of the original
-`kjyxgeldpfef`, which has been deleted). CDK was reconciled via the
-zombie-resource path (PR #268) — the old `Postgres9DC8BB04` logical id
-is a CFN zombie, and a parallel `PostgresEncrypted` construct adopts
-the live instance via `cdk import`. See the header docstring of
-`infra/stacks/database.py` for the rationale and the don't-mutate-the-
-zombies rule.
-
-### 3. Pre-launch infra revert
-See `docs/PRE_LAUNCH_INFRA_CHECKLIST.md` — infra was deliberately undersized while there are zero users. Before real users land, apply in `infra/stacks/database.py`:
-- RDS: `t4g.micro` → `t4g.small`, backup retention 1 day → 7 days, consider Multi-AZ
-- Redis: `cache.t4g.micro` → `cache.t4g.small`, single-node → 2-node with failover
-- ECS: increase CPU/memory on API and worker task definitions
-- Then `cdk deploy`
-
-### 4. Cost data to collect (after 7–14 days of traffic)
-See `MASTER_TODO.md` "Cost Optimization" section — list of AWS Cost Explorer / Compute Optimizer / CloudWatch queries to run and bring back for right-sizing decisions.
+The old AWS RDS encryption / SES / pre-launch-resize / cost-collection P0 items
+are obsolete under the new stack and have been removed.
 
 ---
 

--- a/CLOUD_MIGRATION_GUIDE.md
+++ b/CLOUD_MIGRATION_GUIDE.md
@@ -1,4 +1,12 @@
-# Cloud Migration Guide — ListingJet
+# Cloud Migration Guide — ListingJet (AWS — SUPERSEDED)
+
+> ⚠️ **SUPERSEDED.** ListingJet is migrating **off AWS** to Render + Supabase +
+> Upstash + Cloudflare R2 + Temporal Cloud. This document describes the original
+> AWS/CDK deployment and is retained only as historical reference for the
+> decommission. For the current deploy target and cutover steps see:
+> - `render.yaml` (Render blueprint)
+> - `docs/runbooks/render-supabase-cutover.md` (compute/DB/cache/Temporal cutover + AWS teardown)
+> - `docs/runbooks/r2-cutover.md` (S3 → R2 storage cutover)
 
 ## Status: NOT YET DEPLOYED — Save for when you're ready
 

--- a/docs/runbooks/r2-cutover.md
+++ b/docs/runbooks/r2-cutover.md
@@ -1,0 +1,153 @@
+# Cloudflare R2 Cutover Runbook
+
+ListingJet's media storage is migrating from **AWS S3** to **Cloudflare R2** as part of [Phase 1 of the Render+Supabase migration](../../.. /.claude/plans/breezy-foraging-karp.md). Code is already cutover-ready (PR #285): `StorageService` uses any S3-compatible endpoint when `S3_ENDPOINT_URL` is set. This runbook is the operational side — provisioning R2, syncing data, flipping env vars, smoke testing, rollback.
+
+**Estimated downtime**: 0. The cutover is read-flip-then-rewrite — old S3 reads stay live until the env var changes, R2 starts serving the moment env var is set on the next deploy.
+
+**Estimated effort**: ~30–45 minutes once you have a Cloudflare account.
+
+---
+
+## Prerequisites
+
+- Cloudflare account (free tier is fine — R2 has 10 GB free + $0 egress)
+- Local AWS CLI logged in to the ListingJet account
+- `rclone` installed (`brew install rclone` / `choco install rclone`) OR willingness to use `aws s3 sync` to a temp local dir + upload script
+- PR #285 merged and deployed (so the code can read `S3_ENDPOINT_URL`)
+
+---
+
+## Steps
+
+### 1. Provision R2 in Cloudflare
+
+In the Cloudflare dashboard:
+
+1. **R2 → Create bucket** — name: `listingjet-media`. Location hint: leave default (auto). Click Create.
+2. **R2 → Manage R2 API Tokens → Create API token**:
+   - Name: `listingjet-prod`
+   - Permissions: **Object Read & Write**
+   - Bucket: `listingjet-media` (scope it down)
+   - TTL: forever (or set a rotation reminder)
+   - Click Create. **Copy the Access Key ID, Secret Access Key, and the S3 endpoint URL.** They're shown once.
+
+The endpoint URL looks like `https://<32-char-hex-account-id>.r2.cloudflarestorage.com`.
+
+### 2. Sync existing S3 contents to R2
+
+Source bucket: `listingjet-media-265911026550-us-east-1` (per `infra/stacks/services.py`). Confirm the exact name:
+
+```bash
+aws s3api list-buckets --query "Buckets[?starts_with(Name, 'listingjet-media')].Name" --output text
+```
+
+Configure rclone with both remotes (one-time):
+
+```bash
+rclone config create aws-s3 s3 provider AWS region us-east-1 access_key_id <AWS_KEY> secret_access_key <AWS_SECRET>
+rclone config create r2 s3 provider Cloudflare region auto endpoint <R2_ENDPOINT_URL> access_key_id <R2_KEY> secret_access_key <R2_SECRET>
+```
+
+Dry-run the sync first to see what'll move and how big it is:
+
+```bash
+rclone sync aws-s3:listingjet-media-265911026550-us-east-1 r2:listingjet-media --dry-run --progress
+```
+
+If the size and file count look right, do it for real:
+
+```bash
+rclone sync aws-s3:listingjet-media-265911026550-us-east-1 r2:listingjet-media --progress
+```
+
+For larger payloads, add `--transfers 16 --checkers 32` to parallelize. R2 has $0 ingress, so no cost worry.
+
+Verify counts match:
+
+```bash
+aws s3 ls s3://listingjet-media-265911026550-us-east-1 --recursive --summarize | tail -3
+rclone size r2:listingjet-media
+```
+
+Total size and object count should be identical (or off by a few from in-flight uploads).
+
+### 3. Flip env vars on the running deploy
+
+Today the app runs on AWS ECS with secrets in Secrets Manager. Add three new keys to the `listingjet/app` secret:
+
+```bash
+aws secretsmanager get-secret-value --secret-id listingjet/app --query SecretString --output text > /tmp/app.json
+# edit /tmp/app.json — add:
+#   "S3_ENDPOINT_URL": "https://<account>.r2.cloudflarestorage.com",
+#   "S3_ACCESS_KEY_ID": "<R2_KEY>",
+#   "S3_SECRET_ACCESS_KEY": "<R2_SECRET>"
+aws secretsmanager put-secret-value --secret-id listingjet/app --secret-string "$(cat /tmp/app.json)"
+rm /tmp/app.json
+```
+
+Force ECS to pick up the new values (running tasks keep the old env until restart):
+
+```bash
+aws ecs update-service --cluster listingjet --service listingjet-api --force-new-deployment
+aws ecs update-service --cluster listingjet --service listingjet-worker --force-new-deployment
+```
+
+Wait for both to roll:
+
+```bash
+aws ecs describe-services --cluster listingjet --services listingjet-api listingjet-worker \
+  --query "services[*].[serviceName,deployments[0].rolloutState]" --output text
+```
+
+Both should report `COMPLETED` (typically 2–3 minutes).
+
+### 4. Smoke test
+
+Through the running app, exercise each of the four `StorageService` operations:
+
+| Operation | How to trigger |
+|---|---|
+| **upload** | Upload a photo via the listing creation wizard (frontend) — completes if the worker can write to R2 |
+| **presigned_url** | Open a listing detail page that displays photos — the gallery loads from presigned R2 URLs |
+| **download** | Trigger any pipeline activity that downloads originals (e.g. retry a workflow) |
+| **delete** | Delete an asset from a listing |
+
+Backend check — tail worker logs for any `StorageError`:
+
+```bash
+MSYS_NO_PATHCONV=1 aws logs filter-log-events --log-group-name '/listingjet/worker' \
+  --start-time $(($(date +%s%3N) - 600000)) --filter-pattern "StorageError" --max-items 10
+```
+
+If empty for 10 minutes after a real listing flow, cutover is healthy.
+
+### 5. Decommission AWS S3 (optional, do later)
+
+**Don't rush this.** Keep the AWS bucket for a week or two as a rollback safety net. Once you're confident R2 is healthy:
+
+```bash
+aws s3 rb s3://listingjet-media-265911026550-us-east-1 --force
+```
+
+When the CDK stack is torn down in Phase 3, the bucket goes with it.
+
+---
+
+## Rollback
+
+The whole cutover is a 3-env-var flip. To revert:
+
+1. Edit `listingjet/app` secret — remove `S3_ENDPOINT_URL`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY` (or set them empty).
+2. `aws ecs update-service ... --force-new-deployment` for both api and worker.
+3. App falls back to default boto3 credential chain → AWS S3 with IAM role.
+
+R2 keeps the data; nothing is destroyed by the rollback. New writes during the R2 window stay in R2 and are not present in S3 (this is a real, but small, consequence — usually <1 hour of writes if rolling back fast).
+
+---
+
+## Common gotchas
+
+- **`region: auto` vs `region: us-east-1`** — R2 wants `auto`. The app reads `aws_region` from `AWS_REGION`. Either set `AWS_REGION=auto` for the R2-using services, OR leave it as `us-east-1` (boto3 sigv4 still works because the signature is computed against the endpoint URL, not the region — but `auto` is the supported config).
+- **Presigned PUT URLs** — used by the photo upload wizard via `generate_presigned_post`. R2 supports this since it's standard S3 sigv4. Test specifically by uploading a photo through the wizard — that's the only call site that uses POST presigning.
+- **CORS on R2 bucket** — if the frontend uploads directly to R2 via presigned URLs (it does), the R2 bucket needs a CORS policy allowing the Vercel origin. In the Cloudflare dashboard: R2 → bucket → Settings → CORS Policy → add an entry allowing `https://listingjet.ai` and the Vercel preview URL pattern with `PUT`, `POST`, `GET` methods.
+- **Public asset URLs** — if any code constructs raw S3 URLs (`https://bucket.s3.region.amazonaws.com/key`), they won't work on R2. Audit before flipping. As of PR #285 all asset URLs go through `presigned_url`, which uses the configured client — safe.

--- a/docs/runbooks/render-supabase-cutover.md
+++ b/docs/runbooks/render-supabase-cutover.md
@@ -1,0 +1,156 @@
+# Render + Supabase Cutover Runbook (off AWS)
+
+Moves ListingJet's **compute** (ECS Fargate → Render), **database** (RDS → Supabase),
+**cache** (ElastiCache → Upstash), and **workflow engine** (self-hosted Temporal on
+Fargate → Temporal Cloud). Storage (S3 → Cloudflare R2) is covered separately in
+[`r2-cutover.md`](./r2-cutover.md) — do that one first or in parallel.
+
+All the **code** for this is already in place:
+- `render.yaml` — Render blueprint for the API (web) + worker services.
+- `connect_temporal()` in `src/listingjet/temporal_client.py` — adds TLS + API-key auth when `TEMPORAL_API_KEY` is set, used by the client, worker, and health check.
+- `db_use_pgbouncer` in config — disables asyncpg's prepared-statement cache for the Supabase pooler.
+- `.github/workflows/deploy.yml` — test-gated Render deploy via deploy hooks (replaces the ECS/ECR pipeline).
+
+This runbook is the **operational** side: provisioning the managed services, moving data, flipping DNS, and decommissioning AWS.
+
+> **Order of operations.** Storage (R2) and DB (Supabase) data syncs can run ahead
+> of time with the app still live on AWS. The actual cutover is a DNS/secret flip
+> with a short read-only window for the DB copy. Plan for ~15–30 min of write
+> downtime during the final DB sync, or use logical replication for near-zero.
+
+---
+
+## 0. Prerequisites
+
+- Accounts: [Render](https://render.com), [Supabase](https://supabase.com), [Upstash](https://upstash.com), [Temporal Cloud](https://cloud.temporal.io), [Cloudflare](https://cloudflare.com) (for R2 + DNS).
+- Local: `psql`, `pg_dump`/`pg_restore` (Postgres 16 client), AWS CLI logged in to the ListingJet account, `rclone` (for R2).
+- The R2 cutover (`r2-cutover.md`) done or in flight.
+
+---
+
+## 1. Provision the managed services
+
+### 1a. Supabase (Postgres)
+1. Create a project (region close to Render's `oregon` → US West). Save the DB password.
+2. **Project Settings → Database → Connection string**:
+   - **Direct** (port 5432) → `DATABASE_URL_SYNC` (Alembic, `pg_restore`).
+   - **Transaction pooler** (port 6543) → `DATABASE_URL`. Set `DB_USE_PGBOUNCER=true`.
+3. ListingJet uses **Row-Level Security** (`app.current_tenant`). RLS policies travel with the schema dump, so nothing special here — but do **not** run the app as the Supabase `postgres` superuser if you can avoid it (superusers bypass RLS). Create a dedicated `listingjet` login role with `BYPASSRLS = false` and use it in both URLs. See `docs/PROJECT_OVERVIEW_FOR_LLM.md` for the RLS pattern.
+
+### 1b. Upstash (Redis)
+1. Create a Redis database (region = US West). Eviction: `noeviction` (we use it for rate-limiting + sessions, not as a cache that can drop keys silently).
+2. Copy the **`rediss://`** URL (TLS) → `REDIS_URL`. `redis.asyncio.from_url` handles `rediss://` natively; no code change.
+
+### 1c. Temporal Cloud
+1. Create a namespace (e.g. `listingjet-prod.<account>`). Region = US West.
+2. **Settings → API Keys → Create** an API key for the namespace.
+3. Record:
+   - `TEMPORAL_HOST` = `<namespace>.<account>.tmprl.cloud:7233`
+   - `TEMPORAL_NAMESPACE` = `<namespace>.<account>`
+   - `TEMPORAL_API_KEY` = the key
+   TLS is enabled automatically by `connect_temporal()` whenever the API key is set.
+4. Temporal has **no workflow state to migrate** — the pipeline is fire-per-listing and the only durable schedules (`demo-cleanup-hourly`, `baseline-aggregation-weekly`) are re-created idempotently by the worker on boot (`_ensure_schedules`). Any listing mid-pipeline at cutover should be drained or re-run (see step 4).
+
+### 1d. Render (compute)
+1. **New → Blueprint**, point at this repo. Render reads `render.yaml` and proposes `listingjet-api` (web) + `listingjet-worker`.
+2. It also creates the `listingjet-shared` env group. Fill in every `sync: false` key (DB, Redis, Temporal, R2, Stripe, providers, Resend, Sentry — see `.env.production.example`).
+3. Create the services but **don't** point DNS at them yet.
+4. **Deploy hooks**: each service → Settings → Deploy Hook. Add to GitHub repo secrets as `RENDER_DEPLOY_HOOK_API` and `RENDER_DEPLOY_HOOK_WORKER` (used by `deploy.yml`). `autoDeploy` is off, so deploys only fire after CI is green.
+
+---
+
+## 2. Migrate the database (RDS → Supabase)
+
+Find the live RDS endpoint:
+```bash
+aws rds describe-db-instances \
+  --query "DBInstances[?DBInstanceIdentifier=='listingjet-postgres-encrypted'].Endpoint.Address" \
+  --output text
+```
+
+**Option A — dump/restore (simplest, ~15–30 min write downtime).**
+1. Put the app in maintenance / scale ECS services to 0 to stop writes:
+   ```bash
+   aws ecs update-service --cluster listingjet --service listingjet-api --desired-count 0
+   aws ecs update-service --cluster listingjet --service listingjet-worker --desired-count 0
+   ```
+2. Dump and restore (schema + data, RLS policies and roles included):
+   ```bash
+   pg_dump --no-owner --no-privileges -Fc \
+     "postgresql://listingjet:<pass>@<rds-endpoint>:5432/listingjet" > listingjet.dump
+   pg_restore --no-owner --no-privileges -d "$DATABASE_URL_SYNC" listingjet.dump
+   ```
+3. Stamp Alembic and verify head matches the repo:
+   ```bash
+   DATABASE_URL_SYNC="<supabase-direct>" alembic current   # should report 051_…
+   ```
+   The migration chain is 001→051 linear; the dump already carries the schema, so do **not** run `upgrade head` against a freshly-restored DB unless `current` is behind.
+
+**Option B — logical replication (near-zero downtime).** Use Supabase's external-source
+replication or `pglogical` from RDS. Heavier setup; only worth it if the write-downtime
+window in Option A is unacceptable. For a pre-/low-traffic launch, Option A is fine.
+
+Sanity check row counts on a few core tables (`tenants`, `users`, `listings`, `credit_accounts`) match between source and target before proceeding.
+
+---
+
+## 3. Cut over
+
+1. Confirm the `listingjet-shared` env group on Render has the **Supabase**, **Upstash**, **Temporal Cloud**, and **R2** values filled in.
+2. Trigger the first Render deploy (push to `main`, or hit the deploy hooks). The API's `preDeployCommand` runs `alembic upgrade head` — a no-op if the restore was current, a safety net otherwise.
+3. Watch both services reach **live**; the API health check (`/health`) must be green (it pings Postgres, Redis, and Temporal).
+4. **Repoint the frontend.** `vercel.json` rewrites `/api/*` → `https://api.listingjet.ai`. Update the `api.listingjet.ai` DNS record (Cloudflare) to the Render service's URL/custom domain. Add `api.listingjet.ai` as a custom domain on the `listingjet-api` Render service so its TLS cert provisions.
+5. Re-run any listings that were mid-pipeline at the RDS freeze (their workflows didn't survive the Temporal cluster change). Find them by `listings.status` in (`PROCESSING`, `REVIEW`, `EXPORTING`) and retry from the admin UI.
+
+---
+
+## 4. Smoke test
+
+- Sign in, create a listing, upload photos (exercises R2 presigned POST + Supabase writes).
+- Watch the pipeline run end-to-end (exercises Temporal Cloud + worker + R2 reads/writes).
+- Approve + export a listing (MLS bundle presigned URL from R2).
+- Confirm a transactional email arrives (Resend).
+- Tail Render logs for both services — no `StorageError`, no DB connection errors, no Temporal auth errors.
+
+---
+
+## 5. Decommission AWS (Phase 3 — do after a confidence window)
+
+**Wait a week or two** with the new stack healthy before tearing anything down — AWS is your rollback.
+
+Once confident, tear down the CDK-managed infra. The stacks are in `infra/`:
+```bash
+cd infra && pip install -r requirements.txt
+cdk destroy ListingJetMonitoring ListingJetCI ListingJetServices ListingJetCDN ListingJetDatabase ListingJetNetwork
+```
+Notes:
+- `ListingJetDatabase` adopts the live RDS via the zombie-import path (see the docstring in `infra/stacks/database.py`). Confirm a final manual snapshot exists before destroy, or take one:
+  `aws rds create-db-snapshot --db-instance-identifier listingjet-postgres-encrypted --db-snapshot-identifier final-pre-teardown`.
+- The R2 cutover runbook covers deleting the S3 media bucket. Don't delete it until R2 has fully taken over.
+- Delete the `listingjet/app` Secrets Manager secret and the GitHub OIDC deploy role last.
+- Remove leftover GitHub repo secrets: `AWS_DEPLOY_ROLE_ARN`.
+
+After teardown, delete the now-unused `infra/` directory and `cdk.json` in a follow-up PR (kept in-repo until now precisely so `cdk destroy` works).
+
+---
+
+## Rollback
+
+Before DNS is flipped (step 3.4), rollback is trivial: scale the ECS services back up
+(`--desired-count 1`) and you're back on AWS — the RDS data is untouched (we dumped, not
+moved). After DNS is flipped and real writes have landed in Supabase, rolling back means
+re-syncing Supabase→RDS for the delta, so treat the DNS flip as the point of no easy return
+and smoke-test hard before it.
+
+---
+
+## Gotchas
+
+- **Supabase pooler + asyncpg**: must set `DB_USE_PGBOUNCER=true`, else you'll see
+  `prepared statement "__asyncpg_..." already exists` under load. Alembic uses
+  `DATABASE_URL_SYNC` against the **direct** port (5432), not the pooler.
+- **RLS / superuser**: don't run the app as Supabase `postgres` (superuser bypasses RLS,
+  which would silently disable tenant isolation). Use a non-superuser `listingjet` role.
+- **Upstash TLS**: the URL is `rediss://` (two s's). A plain `redis://` will fail the TLS handshake.
+- **Temporal Cloud namespace format**: `TEMPORAL_NAMESPACE` is `<namespace>.<account>`, not just `<namespace>`.
+- **Render PORT**: Render injects `PORT`; `entrypoint.sh` already honors it. Don't hardcode 8000.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,20 @@
+# infra/ — AWS CDK (DECOMMISSION-ONLY)
+
+> **ListingJet has migrated off AWS** to Render + Supabase + Upstash +
+> Cloudflare R2 + Temporal Cloud. These CDK stacks are **no longer the deploy
+> target.** They are kept here for one reason only: so the still-live AWS
+> resources can be torn down cleanly with `cdk destroy`.
+
+**Do not** add features, deploy, or `cdk deploy` these stacks. New
+infrastructure lives in [`render.yaml`](../render.yaml) and the managed-service
+dashboards.
+
+## What this still does
+- `cdk destroy` the remaining AWS resources during decommission (Phase 3 of the
+  migration). See [`docs/runbooks/render-supabase-cutover.md`](../docs/runbooks/render-supabase-cutover.md#5-decommission-aws-phase-3--do-after-a-confidence-window).
+- The `ListingJetDatabase` stack adopts the live encrypted RDS via the
+  zombie-import path — read the header docstring in `stacks/database.py` before
+  touching anything (the don't-mutate-the-zombies rule still applies until destroy).
+
+Once AWS is fully decommissioned and a confidence window has passed, delete this
+directory and `cdk.json` in a follow-up PR.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,130 @@
+# Render Blueprint — ListingJet backend (API + Temporal worker)
+#
+# This replaces the AWS ECS Fargate deployment. The API and worker share the
+# repo Dockerfile; the entrypoint selects the mode (`api` vs `worker`).
+#
+# Managed data services live OUTSIDE Render and are wired in via the shared
+# env-var group below (all `sync: false`, i.e. set once in the Render
+# dashboard — Render never stores their values in this file):
+#   - Postgres  -> Supabase            (DATABASE_URL / DATABASE_URL_SYNC)
+#   - Redis     -> Upstash             (REDIS_URL, rediss:// TLS)
+#   - Storage   -> Cloudflare R2       (S3_ENDPOINT_URL + S3_* keys)
+#   - Temporal  -> Temporal Cloud      (TEMPORAL_HOST/NAMESPACE/API_KEY)
+#
+# First-time setup and the full cutover steps are in
+# docs/runbooks/render-supabase-cutover.md.
+
+services:
+  - type: web
+    name: listingjet-api
+    runtime: docker
+    dockerfilePath: ./Dockerfile
+    dockerContext: .
+    dockerCommand: ./entrypoint.sh api
+    plan: starter
+    region: oregon
+    healthCheckPath: /health
+    autoDeploy: false
+    # Gate each deploy on a successful migration (mirrors the old ECS one-shot
+    # migrate task). Runs against the new image before traffic shifts; a
+    # non-zero exit aborts the deploy. The `api` startup path also runs a
+    # best-effort catch-up, but this is the authoritative, deploy-blocking run.
+    preDeployCommand: ./entrypoint.sh migrate
+    envVars:
+      - fromGroup: listingjet-shared
+      - key: APP_ENV
+        value: production
+      # Render injects PORT automatically; entrypoint.sh honors it.
+
+  - type: worker
+    name: listingjet-worker
+    runtime: docker
+    dockerfilePath: ./Dockerfile
+    dockerContext: .
+    dockerCommand: ./entrypoint.sh worker
+    plan: starter
+    region: oregon
+    autoDeploy: false
+    envVars:
+      - fromGroup: listingjet-shared
+      - key: APP_ENV
+        value: production
+
+# Shared secrets / config. Set the real values once in the Render dashboard
+# (Environment Groups -> listingjet-shared). Keep this list in sync with
+# .env.production.example — anything there that prod needs can be added here.
+envVarGroups:
+  - name: listingjet-shared
+    envVars:
+      # --- Database (Supabase) ---
+      # Use the Supabase transaction pooler (port 6543) for DATABASE_URL and set
+      # DB_USE_PGBOUNCER=true so asyncpg disables its prepared-statement cache.
+      - key: DATABASE_URL
+        sync: false
+      - key: DATABASE_URL_SYNC
+        sync: false
+      - key: DB_USE_PGBOUNCER
+        value: "true"
+      # --- Cache (Upstash, rediss://) ---
+      - key: REDIS_URL
+        sync: false
+      # --- Temporal Cloud ---
+      - key: TEMPORAL_HOST
+        sync: false
+      - key: TEMPORAL_NAMESPACE
+        sync: false
+      - key: TEMPORAL_API_KEY
+        sync: false
+      # --- Object storage (Cloudflare R2) ---
+      - key: S3_BUCKET_NAME
+        sync: false
+      - key: S3_ENDPOINT_URL
+        sync: false
+      - key: S3_ACCESS_KEY_ID
+        sync: false
+      - key: S3_SECRET_ACCESS_KEY
+        sync: false
+      - key: AWS_REGION
+        value: auto
+      # CloudWatch is AWS-only — keep it off here.
+      - key: CLOUDWATCH_ENABLED
+        value: "false"
+      # --- Auth / app ---
+      - key: JWT_SECRET
+        sync: false
+      - key: FIELD_ENCRYPTION_KEY
+        sync: false
+      - key: FRONTEND_URL
+        value: https://listingjet.ai
+      - key: CORS_ORIGINS
+        value: https://listingjet.ai
+      # --- Payments ---
+      - key: STRIPE_SECRET_KEY
+        sync: false
+      - key: STRIPE_WEBHOOK_SECRET
+        sync: false
+      # --- AI / media providers ---
+      - key: OPENAI_API_KEY
+        sync: false
+      - key: ANTHROPIC_API_KEY
+        sync: false
+      - key: GOOGLE_VISION_API_KEY
+        sync: false
+      - key: CANVA_API_KEY
+        sync: false
+      - key: CANVA_DEFAULT_TEMPLATE_ID
+        sync: false
+      - key: KLING_ACCESS_KEY
+        sync: false
+      - key: KLING_SECRET_KEY
+        sync: false
+      - key: ELEVENLABS_API_KEY
+        sync: false
+      # --- Email (Resend) ---
+      - key: EMAIL_ENABLED
+        value: "true"
+      - key: RESEND_API_KEY
+        sync: false
+      # --- Monitoring ---
+      - key: SENTRY_DSN
+        sync: false

--- a/src/listingjet/api/health.py
+++ b/src/listingjet/api/health.py
@@ -57,8 +57,8 @@ async def deep_health():
 
     # Temporal
     try:
-        from temporalio.client import Client
-        client = await Client.connect(settings.temporal_host, namespace=settings.temporal_namespace)
+        from listingjet.temporal_client import connect_temporal
+        client = await connect_temporal()
         await client.service_client.check_health()
         components["temporal"] = "ok"
     except Exception as e:

--- a/src/listingjet/config/__init__.py
+++ b/src/listingjet/config/__init__.py
@@ -77,9 +77,17 @@ class Settings(BaseSettings):
     # (invite accept, password reset, etc).
     frontend_url: str = "https://listingjet.ai"
 
-    # S3
+    # S3 / object storage. Set s3_endpoint_url + s3_access_key_id + s3_secret_access_key
+    # to point at an S3-compatible backend (e.g. Cloudflare R2). Empty endpoint URL
+    # means default AWS S3 with the boto3 credential chain (IAM role, env, profile).
     s3_bucket_name: str = ""
     aws_region: str = "us-east-1"
+    s3_endpoint_url: str = ""
+    s3_access_key_id: str = ""
+    s3_secret_access_key: str = ""
+
+    # CloudWatch metrics — opt-in. Set true on AWS deploys; off everywhere else.
+    cloudwatch_enabled: bool = False
 
     # Monitoring
     sentry_dsn: str = ""

--- a/src/listingjet/config/__init__.py
+++ b/src/listingjet/config/__init__.py
@@ -66,9 +66,15 @@ class Settings(BaseSettings):
     stripe_price_enterprise: str = ""
 
     # Temporal
+    # For Temporal Cloud set temporal_host to "<namespace>.<account>.tmprl.cloud:7233",
+    # temporal_namespace to "<namespace>.<account>", and temporal_api_key to the
+    # Cloud API key. TLS is implied whenever an API key is set (it can also be
+    # forced on with temporal_tls for mTLS / self-hosted-with-TLS setups).
     temporal_host: str = "localhost:7233"
     temporal_namespace: str = "default"
     temporal_task_queue: str = "listingjet-main"
+    temporal_api_key: str = ""
+    temporal_tls: bool = False
 
     # Redis
     redis_url: str = "redis://localhost:6379/0"

--- a/src/listingjet/monitoring/metrics.py
+++ b/src/listingjet/monitoring/metrics.py
@@ -26,8 +26,12 @@ def emit_metric(
     unit: str = "None",
     dimensions: dict[str, str] | None = None,
 ) -> None:
-    """Emit a CloudWatch custom metric. No-op in development."""
+    """Emit a CloudWatch custom metric. No-op in development or when
+    settings.cloudwatch_enabled is False (default for non-AWS environments).
+    """
     if settings.app_env == "development":
+        return
+    if not settings.cloudwatch_enabled:
         return
 
     try:

--- a/src/listingjet/services/storage.py
+++ b/src/listingjet/services/storage.py
@@ -1,6 +1,9 @@
 # src/listingjet/services/storage.py
 """
-S3-backed storage service.
+S3-compatible object storage.
+
+Works with AWS S3 (default) or any S3-compatible backend (e.g. Cloudflare R2)
+when settings.s3_endpoint_url is set.
 
 All asset uploads use a consistent key scheme:
   listings/{listing_id}/{asset_type}/{filename}
@@ -19,14 +22,21 @@ logger = logging.getLogger(__name__)
 
 
 class StorageError(Exception):
-    """Raised when an S3 operation fails."""
+    """Raised when an object storage operation fails."""
 
 
 class StorageService:
     def __init__(self, bucket: str = None, region: str = None):
         self._bucket = bucket or settings.s3_bucket_name
         self._region = region or settings.aws_region
-        self._client = boto3.client("s3", region_name=self._region)
+
+        client_kwargs = {"region_name": self._region}
+        if settings.s3_endpoint_url:
+            client_kwargs["endpoint_url"] = settings.s3_endpoint_url
+        if settings.s3_access_key_id and settings.s3_secret_access_key:
+            client_kwargs["aws_access_key_id"] = settings.s3_access_key_id
+            client_kwargs["aws_secret_access_key"] = settings.s3_secret_access_key
+        self._client = boto3.client("s3", **client_kwargs)
 
     def upload(self, key: str, data: bytes | io.IOBase, content_type: str) -> str:
         """Upload bytes or file-like object. Returns the S3 key."""

--- a/src/listingjet/temporal_client.py
+++ b/src/listingjet/temporal_client.py
@@ -10,13 +10,34 @@ from listingjet.workflows.listing_pipeline import ListingPipeline, ListingPipeli
 logger = logging.getLogger(__name__)
 
 
+async def connect_temporal(**overrides) -> Client:
+    """Connect to Temporal, honoring Temporal Cloud auth from settings.
+
+    Single source of truth for how every entrypoint (API client, worker,
+    health check) reaches Temporal. When ``temporal_api_key`` is set we are
+    talking to Temporal Cloud, which requires TLS — so TLS is enabled
+    automatically whenever an API key is present (and can also be forced on
+    via ``temporal_tls`` for mTLS / TLS-fronted self-hosted clusters).
+
+    ``overrides`` are merged last so callers can pass extras like
+    ``interceptors=...`` without duplicating the auth wiring.
+    """
+    kwargs: dict = {"namespace": settings.temporal_namespace}
+    if settings.temporal_api_key:
+        kwargs["api_key"] = settings.temporal_api_key
+    if settings.temporal_tls or settings.temporal_api_key:
+        kwargs["tls"] = True
+    kwargs.update(overrides)
+    return await Client.connect(settings.temporal_host, **kwargs)
+
+
 class TemporalClient:
     def __init__(self):
         self._client: Client | None = None
 
     async def _connect(self) -> Client:
         if self._client is None:
-            self._client = await Client.connect(settings.temporal_host, namespace=settings.temporal_namespace)
+            self._client = await connect_temporal()
         return self._client
 
     async def start_pipeline(

--- a/src/listingjet/workflows/worker.py
+++ b/src/listingjet/workflows/worker.py
@@ -10,6 +10,7 @@ from temporalio.worker import Worker
 from listingjet.activities.pipeline import ALL_ACTIVITIES
 from listingjet.config import settings
 from listingjet.telemetry import init_tracing
+from listingjet.temporal_client import connect_temporal
 from listingjet.workflows.baseline_aggregation import BaselineAggregationWorkflow, run_baseline_aggregation
 from listingjet.workflows.demo_cleanup import DemoCleanupWorkflow, run_demo_cleanup
 from listingjet.workflows.listing_pipeline import ListingPipeline
@@ -59,11 +60,7 @@ def _get_interceptors() -> list:
 async def create_worker() -> Worker:
     init_tracing()
     interceptors = _get_interceptors()
-    client = await Client.connect(
-        settings.temporal_host,
-        namespace=settings.temporal_namespace,
-        interceptors=interceptors,
-    )
+    client = await connect_temporal(interceptors=interceptors)
     return Worker(
         client,
         task_queue=settings.temporal_task_queue,

--- a/tests/test_monitoring/test_metrics.py
+++ b/tests/test_monitoring/test_metrics.py
@@ -11,6 +11,7 @@ def test_emit_metric_calls_cloudwatch():
     with patch("listingjet.monitoring.metrics._get_cloudwatch_client", return_value=mock_client):
         with patch("listingjet.monitoring.metrics.settings") as mock_settings:
             mock_settings.app_env = "production"
+            mock_settings.cloudwatch_enabled = True
             emit_metric("RequestCount", 1, unit="Count", dimensions={"endpoint": "/health"})
             mock_client.put_metric_data.assert_called_once()
             call_args = mock_client.put_metric_data.call_args[1]
@@ -24,6 +25,19 @@ def test_emit_metric_noop_in_development():
     from listingjet.monitoring.metrics import emit_metric
     with patch("listingjet.monitoring.metrics.settings") as mock_settings:
         mock_settings.app_env = "development"
+        mock_settings.cloudwatch_enabled = True  # even when enabled, dev noops
+        with patch("listingjet.monitoring.metrics._get_cloudwatch_client") as mock_cw:
+            emit_metric("RequestCount", 1)
+            mock_cw.assert_not_called()
+
+
+def test_emit_metric_noop_when_cloudwatch_disabled():
+    """In non-dev environments, cloudwatch_enabled=False (the default for
+    non-AWS deploys) must skip emitting and avoid creating a client."""
+    from listingjet.monitoring.metrics import emit_metric
+    with patch("listingjet.monitoring.metrics.settings") as mock_settings:
+        mock_settings.app_env = "production"
+        mock_settings.cloudwatch_enabled = False
         with patch("listingjet.monitoring.metrics._get_cloudwatch_client") as mock_cw:
             emit_metric("RequestCount", 1)
             mock_cw.assert_not_called()
@@ -35,7 +49,7 @@ async def test_time_metric_decorator():
 
     @time_metric("TestDuration")
     async def slow_function():
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.05)
         return "done"
 
     with patch("listingjet.monitoring.metrics.emit_metric") as mock_emit:
@@ -44,4 +58,5 @@ async def test_time_metric_decorator():
         mock_emit.assert_called_once()
         call_args = mock_emit.call_args
         assert call_args[0][0] == "TestDuration"
-        assert call_args[0][1] >= 10  # at least 10ms
+        # 50ms sleep — assert >=30ms to allow headroom for Windows clock resolution.
+        assert call_args[0][1] >= 30

--- a/tests/test_services/test_storage.py
+++ b/tests/test_services/test_storage.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import boto3
 import pytest
 from moto import mock_aws
@@ -36,3 +38,34 @@ def test_upload_file_like_object(s3_service):
     buf = io.BytesIO(b"image-data")
     key = s3_service.upload(key="listings/abc/photo.jpg", data=buf, content_type="image/jpeg")
     assert key == "listings/abc/photo.jpg"
+
+
+def test_default_aws_client_no_endpoint_url():
+    """Without s3_endpoint_url set, boto3 hits AWS (no custom endpoint)."""
+    with patch("listingjet.services.storage.boto3.client") as mock_client:
+        with patch("listingjet.services.storage.settings") as mock_settings:
+            mock_settings.s3_bucket_name = "default-bucket"
+            mock_settings.aws_region = "us-east-1"
+            mock_settings.s3_endpoint_url = ""
+            mock_settings.s3_access_key_id = ""
+            mock_settings.s3_secret_access_key = ""
+            StorageService()
+            kwargs = mock_client.call_args[1]
+            assert kwargs == {"region_name": "us-east-1"}
+
+
+def test_r2_endpoint_and_creds_passed_to_boto3():
+    """When s3_endpoint_url + creds are set (R2 case), they reach boto3."""
+    with patch("listingjet.services.storage.boto3.client") as mock_client:
+        with patch("listingjet.services.storage.settings") as mock_settings:
+            mock_settings.s3_bucket_name = "media"
+            mock_settings.aws_region = "auto"
+            mock_settings.s3_endpoint_url = "https://acct.r2.cloudflarestorage.com"
+            mock_settings.s3_access_key_id = "AKIA-r2"
+            mock_settings.s3_secret_access_key = "secret-r2"
+            StorageService()
+            kwargs = mock_client.call_args[1]
+            assert kwargs["endpoint_url"] == "https://acct.r2.cloudflarestorage.com"
+            assert kwargs["aws_access_key_id"] == "AKIA-r2"
+            assert kwargs["aws_secret_access_key"] == "secret-r2"
+            assert kwargs["region_name"] == "auto"

--- a/tests/test_temporal_client.py
+++ b/tests/test_temporal_client.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from temporalio.common import WorkflowIDReusePolicy
 
-from listingjet.temporal_client import TemporalClient
+from listingjet.temporal_client import TemporalClient, connect_temporal
 
 
 def _make_client_mock() -> MagicMock:
@@ -42,3 +42,48 @@ async def test_start_pipeline_retry_uses_terminate_if_running():
         await tc.start_pipeline(listing_id="abc", tenant_id="t1", terminate_existing=True)
     kwargs = client.start_workflow.await_args.kwargs
     assert kwargs["id_reuse_policy"] == WorkflowIDReusePolicy.TERMINATE_IF_RUNNING
+
+
+@pytest.mark.asyncio
+async def test_connect_temporal_local_no_tls_no_api_key():
+    """Self-hosted/local: no API key, no TLS — bare namespaced connect."""
+    with patch("listingjet.temporal_client.settings") as s, \
+         patch("listingjet.temporal_client.Client.connect", AsyncMock()) as conn:
+        s.temporal_host = "localhost:7233"
+        s.temporal_namespace = "default"
+        s.temporal_api_key = ""
+        s.temporal_tls = False
+        await connect_temporal()
+    args, kwargs = conn.await_args
+    assert args == ("localhost:7233",)
+    assert kwargs == {"namespace": "default"}
+
+
+@pytest.mark.asyncio
+async def test_connect_temporal_cloud_api_key_implies_tls():
+    """Temporal Cloud: setting an API key must auto-enable TLS."""
+    with patch("listingjet.temporal_client.settings") as s, \
+         patch("listingjet.temporal_client.Client.connect", AsyncMock()) as conn:
+        s.temporal_host = "ns.acct.tmprl.cloud:7233"
+        s.temporal_namespace = "ns.acct"
+        s.temporal_api_key = "tk_secret"
+        s.temporal_tls = False
+        await connect_temporal()
+    kwargs = conn.await_args.kwargs
+    assert kwargs["api_key"] == "tk_secret"
+    assert kwargs["tls"] is True
+    assert kwargs["namespace"] == "ns.acct"
+
+
+@pytest.mark.asyncio
+async def test_connect_temporal_passes_overrides():
+    """Callers (the worker) pass interceptors without re-stating auth."""
+    sentinel = [object()]
+    with patch("listingjet.temporal_client.settings") as s, \
+         patch("listingjet.temporal_client.Client.connect", AsyncMock()) as conn:
+        s.temporal_host = "localhost:7233"
+        s.temporal_namespace = "default"
+        s.temporal_api_key = ""
+        s.temporal_tls = False
+        await connect_temporal(interceptors=sentinel)
+    assert conn.await_args.kwargs["interceptors"] is sentinel


### PR DESCRIPTION
## Summary

Finishes taking ListingJet **off AWS** (ECS Fargate / RDS / ElastiCache / S3 / self-hosted Temporal) onto **Render + Supabase + Upstash + Cloudflare R2 + Temporal Cloud**.

Builds on the Phase 1 storage/metrics work from #285, which is **merged into this branch** so the migration is self-contained. The app config was already largely portable (`DATABASE_URL`, `REDIS_URL`, `PORT`, Resend email); this closes the real remaining gaps.

> The **code + config is done**; the actual cutover (provisioning accounts, syncing data, flipping DNS, decommissioning AWS) is operational and documented in the runbooks — it needs credentials and touches live prod, so it isn't run here.

## What's in here

**Code**
- **Temporal Cloud auth** (the one real code gap): new `connect_temporal()` helper in `temporal_client.py` adds TLS + API-key auth from settings (`temporal_api_key` / `temporal_tls`), with TLS implied whenever an API key is set. Wired into all three `Client.connect` sites — client, worker, health check — plus unit tests for the wiring.

**Deploy / config**
- `render.yaml` — Render blueprint for the API (web) + worker, sharing the Dockerfile via entrypoint mode. Test-gated (`autoDeploy: false`), `preDeployCommand` runs Alembic migrations, shared env group documents the external services.
- `.github/workflows/deploy.yml` — replaces the ECS/ECR pipeline with a test-gated Render deploy via per-service deploy hooks; keeps the Sentry release notification.
- `.env.production.example` — rewritten for Supabase (transaction pooler + `DB_USE_PGBOUNCER`), Upstash (`rediss://`), Temporal Cloud, and R2.

**Docs**
- `docs/runbooks/render-supabase-cutover.md` — provisioning, RDS→Supabase data migration, DNS cutover, smoke test, AWS decommission (`cdk destroy`), rollback.
- `infra/README.md` — marks the CDK **decommission-only** (kept solely so the live AWS resources can be torn down cleanly).
- `CLAUDE.md` + `CLOUD_MIGRATION_GUIDE.md` updated to the new stack; obsolete AWS-ops P0 items removed.

## Verification
- 15 affected unit tests pass (Temporal auth wiring, storage, metrics); all changed modules import; `ruff` clean; `render.yaml` + `deploy.yml` parse. Full pytest needs a live Postgres/Redis and runs in CI.

## Notes for the reviewer
- **`infra/` is intentionally kept**, not deleted — the CDK is the only clean path to `cdk destroy` the still-live AWS resources. Phase 5 of the runbook destroys it, then a follow-up PR removes the directory.
- This branch contains #285's commits. When both land on `main`, git dedupes cleanly — but you may prefer to **merge #285 first, then this**, or merge this and close #285.

https://claude.ai/code/session_01QW8ZAsndUvQXMZPiEY4sXa

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW8ZAsndUvQXMZPiEY4sXa)_