### PR TITLE
chore(infra): guarded AWS decommission script + runnable plan

### DIFF
--- a/docs/runbooks/aws-decommission-plan.md
+++ b/docs/runbooks/aws-decommission-plan.md
@@ -1,0 +1,81 @@
+# AWS Decommission Plan (run from a terminal with AWS creds)
+
+**For:** the local Claude Code session that has AWS credentials.
+**Goal:** delete the entire ListingJet AWS footprint and stop all charges.
+**Context:** ListingJet has migrated off AWS (code-complete — Render + Supabase +
+Upstash + Cloudflare R2 + Temporal Cloud). This is a **pre-launch** deployment with
+**throwaway test data only**, confirmed by the owner. There is nothing to preserve
+beyond an optional final snapshot. The app going offline is expected and fine.
+
+> ⚠️ **Why not just `cdk destroy`?** The CDK config retains the stateful resources:
+> RDS has `deletion_protection=True` + `removal_policy=RETAIN`, and the S3 bucket is
+> RETAIN (`infra/stacks/database.py:180`). `cdk destroy` would **orphan the DB and
+> bucket and keep billing.** Use the script below, which deletes them directly.
+
+## Tooling
+Everything is in **`scripts/aws_decommission.sh`** — dry-run by default, deletes in
+cost-priority order (ECS → NAT → ALB → RDS → ElastiCache → CloudFront → S3/ECR/
+Secrets/Logs), and ends with a scan for resources that silently keep billing.
+
+## Steps for the agent
+
+1. **Confirm identity & region.** Run `aws sts get-caller-identity` and verify it's the
+   ListingJet account. Default region is `us-east-1` (pass `--region` if different).
+
+2. **Dry run first — always.** Review the full list of what would be deleted:
+   ```bash
+   bash scripts/aws_decommission.sh
+   ```
+   Sanity-check the discovered resources (ECS services, the NAT gateway, the ALB, RDS
+   `listingjet-postgres-encrypted`, the Redis group, CloudFront, the `listingjet-media*`
+   bucket, ECR repos, secrets). If anything looks like it belongs to a *different*
+   project, stop and ask the owner before proceeding.
+
+3. **Decide on the final RDS snapshot.** Default keeps one (`listingjet-final-<date>`,
+   ~pennies/mo) as a safety net. Since the data is throwaway, you may skip it with
+   `--no-snapshot` if the owner prefers a truly clean teardown.
+
+4. **Execute.** It will prompt for a typed `DELETE` confirmation:
+   ```bash
+   bash scripts/aws_decommission.sh --execute            # keeps a final RDS snapshot
+   # or
+   bash scripts/aws_decommission.sh --execute --no-snapshot
+   ```
+
+5. **CloudFront needs a second pass.** CloudFront can only be *disabled* synchronously;
+   AWS takes ~10–15 min to deploy the disabled state before it can be deleted. The
+   script prints the exact follow-up `delete-distribution` command per distribution —
+   run it once each distribution shows `Deployed` + `Disabled`:
+   ```bash
+   aws cloudfront list-distributions --query "DistributionList.Items[?contains(Comment,'istingJet')].[Id,Status,Enabled]" --output table
+   # then for each: get ETag, delete-distribution --if-match $ETAG
+   ```
+
+6. **Re-run the leftover scan** a few minutes later (NAT deletion is async, which frees
+   the EIP). A second `--execute` pass is idempotent and will release the now-detached
+   EIP and report anything still present:
+   ```bash
+   bash scripts/aws_decommission.sh --execute --yes
+   ```
+
+7. **Verify $0.** Next day, check **Billing → Cost Explorer** (group by Service). It
+   should trend to ~$0. The free leftovers (VPC, subnets, IGW, empty security groups)
+   are harmless; delete the `ListingJetNetwork` CFN stack last if you want a spotless
+   account: `aws cloudformation delete-stack --stack-name ListingJetNetwork`.
+
+8. **GitHub cleanup (optional).** Remove the now-unused repo secret `AWS_DEPLOY_ROLE_ARN`
+   and the GitHub OIDC deploy role (`ListingJetCI` stack / IAM). The Render deploy uses
+   `RENDER_DEPLOY_HOOK_*` instead.
+
+9. **Repo cleanup (follow-up PR).** Once AWS is gone, delete the `infra/` directory and
+   `cdk.json` — they exist only so this teardown could run. Open a small PR for that.
+
+## Rollback
+There is none after `--execute` beyond the optional final RDS snapshot. That's
+acceptable here (pre-launch, throwaway data). If the owner ever changes their mind about
+preserving data, take a `pg_dump` and `aws s3 sync` to local **before** step 4.
+
+## Reference
+- Migration cutover (for when you stand the app up on Render later):
+  `docs/runbooks/render-supabase-cutover.md` and `docs/runbooks/r2-cutover.md`.
+- The AWS resource definitions being torn down: `infra/` (decommission-only, see `infra/README.md`).

--- a/scripts/aws_decommission.sh
+++ b/scripts/aws_decommission.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# aws_decommission.sh — tear down the ListingJet AWS footprint and stop all charges.
+#
+# Context: ListingJet has migrated off AWS (code-complete) to Render + Supabase +
+# Upstash + Cloudflare R2 + Temporal Cloud. This pre-launch deployment holds only
+# throwaway test data, so the whole AWS footprint can be deleted. This script does
+# that in cost-priority order and ends with a scan for resources that silently keep
+# billing (unattached EIPs, orphan EBS/snapshots).
+#
+# IMPORTANT — your own CDK config has two traps this script handles for you:
+#   - RDS has deletion_protection=True + removal_policy=RETAIN  (infra/stacks/database.py)
+#   - the S3 media bucket defaults to RETAIN
+#   => `cdk destroy` ALONE WOULD ORPHAN THE DB + BUCKET AND KEEP BILLING.
+#   This script deletes the stateful resources directly instead.
+#
+# Usage:
+#   bash scripts/aws_decommission.sh                 # DRY RUN — prints what it would delete
+#   bash scripts/aws_decommission.sh --execute       # actually delete (asks for confirmation)
+#   bash scripts/aws_decommission.sh --execute --no-snapshot   # skip the final RDS snapshot
+#
+# Flags:
+#   --execute       perform deletions (default is dry-run / read-only)
+#   --no-snapshot   delete RDS without a final snapshot (default: take one)
+#   --region REGION AWS region (default: us-east-1)
+#   --yes           skip the interactive "type DELETE" confirmation (for unattended runs)
+#
+# Requires: awscli v2, authenticated to the ListingJet account.
+
+set -uo pipefail
+
+REGION="us-east-1"
+EXECUTE=false
+TAKE_SNAPSHOT=true
+ASSUME_YES=false
+CLUSTER="listingjet"
+RDS_ID="listingjet-postgres-encrypted"
+OLD_SNAPSHOT="handoff-safety-20260414-0830"
+ECR_REPOS=("listingjet-api" "listingjet-worker")
+S3_BUCKET_GLOB="listingjet-media"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --execute) EXECUTE=true ;;
+    --no-snapshot) TAKE_SNAPSHOT=false ;;
+    --yes) ASSUME_YES=true ;;
+    --region) REGION="$2"; shift ;;
+    *) echo "Unknown arg: $1"; exit 2 ;;
+  esac
+  shift
+done
+
+export AWS_PAGER=""
+DATESTAMP="$(date +%Y%m%d-%H%M)"
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+say()  { printf '\n\033[1m%s\033[0m\n' "$*"; }
+info() { printf '  %s\n' "$*"; }
+
+# run: echo the command; only execute it when --execute is set. Never aborts the
+# script on a single failed delete (resources may already be gone / mid-delete).
+run() {
+  if $EXECUTE; then
+    info "RUN: $*"
+    "$@" || info "  (non-fatal: command returned $?)"
+  else
+    info "DRY: $*"
+  fi
+}
+
+require_aws() {
+  command -v aws >/dev/null || { echo "awscli not found"; exit 1; }
+  local who
+  who=$(aws sts get-caller-identity --query 'Arn' --output text 2>/dev/null) \
+    || { echo "ERROR: AWS credentials not configured / not authenticated."; exit 1; }
+  say "Account: $who   Region: $REGION"
+  if ! $EXECUTE; then
+    info "MODE: DRY RUN (read-only). Re-run with --execute to delete."
+  else
+    info "MODE: EXECUTE — resources WILL be deleted."
+  fi
+}
+
+confirm() {
+  $ASSUME_YES && return 0
+  $EXECUTE || return 0
+  echo
+  echo "This permanently deletes the ListingJet AWS deployment in $REGION."
+  read -r -p "Type DELETE to proceed: " ans
+  [ "$ans" = "DELETE" ] || { echo "Aborted."; exit 1; }
+}
+
+# ── 0. RDS: lift deletion protection (must precede delete) ──────────────────────
+prep_rds() {
+  say "[0] RDS — disable deletion protection on $RDS_ID"
+  if aws rds describe-db-instances --db-instance-identifier "$RDS_ID" --region "$REGION" >/dev/null 2>&1; then
+    run aws rds modify-db-instance --db-instance-identifier "$RDS_ID" \
+      --no-deletion-protection --apply-immediately --region "$REGION"
+  else
+    info "RDS instance $RDS_ID not found (already deleted?) — skipping."
+  fi
+}
+
+# ── 1. ECS Fargate (biggest always-on cost) ─────────────────────────────────────
+kill_ecs() {
+  say "[1] ECS — drain + delete services, then the cluster ($CLUSTER)"
+  if ! aws ecs describe-clusters --clusters "$CLUSTER" --region "$REGION" \
+        --query 'clusters[0].status' --output text 2>/dev/null | grep -q ACTIVE; then
+    info "Cluster $CLUSTER not active — skipping."
+    return
+  fi
+  local svcs
+  svcs=$(aws ecs list-services --cluster "$CLUSTER" --region "$REGION" \
+          --query 'serviceArns[]' --output text 2>/dev/null)
+  for arn in $svcs; do
+    local name=${arn##*/}
+    info "service: $name"
+    run aws ecs update-service --cluster "$CLUSTER" --service "$name" --desired-count 0 --region "$REGION"
+    run aws ecs delete-service --cluster "$CLUSTER" --service "$name" --force --region "$REGION"
+  done
+  run aws ecs delete-cluster --cluster "$CLUSTER" --region "$REGION"
+}
+
+# ── 2. NAT Gateways + their Elastic IPs ─────────────────────────────────────────
+kill_nat() {
+  say "[2] NAT Gateways (+ release their EIPs)"
+  local nats
+  nats=$(aws ec2 describe-nat-gateways --region "$REGION" \
+          --filter Name=state,Values=available,pending \
+          --query 'NatGateways[].NatGatewayId' --output text 2>/dev/null)
+  [ -z "$nats" ] && { info "No active NAT gateways."; return; }
+  for n in $nats; do
+    info "nat: $n"
+    run aws ec2 delete-nat-gateway --nat-gateway-id "$n" --region "$REGION"
+  done
+  info "NAT deletion is async (~1-2 min). EIPs are released in the final scan once detached."
+}
+
+# ── 3. Application Load Balancers + target groups ───────────────────────────────
+kill_alb() {
+  say "[3] Load balancers + target groups (tagged for ListingJet)"
+  local lbs
+  lbs=$(aws elbv2 describe-load-balancers --region "$REGION" \
+         --query 'LoadBalancers[].LoadBalancerArn' --output text 2>/dev/null)
+  for lb in $lbs; do
+    # only touch LBs tagged by the CDK stack
+    if aws elbv2 describe-tags --resource-arns "$lb" --region "$REGION" \
+         --query 'TagDescriptions[0].Tags[?starts_with(Value,`ListingJet`)]' \
+         --output text 2>/dev/null | grep -qi listingjet; then
+      info "alb: ${lb##*/}"
+      run aws elbv2 delete-load-balancer --load-balancer-arn "$lb" --region "$REGION"
+    fi
+  done
+  local tgs
+  tgs=$(aws elbv2 describe-target-groups --region "$REGION" \
+         --query 'TargetGroups[?starts_with(TargetGroupName,`Listi`) || contains(TargetGroupName,`listingjet`)].TargetGroupArn' \
+         --output text 2>/dev/null)
+  for tg in $tgs; do
+    info "target-group: ${tg##*/}"
+    run aws elbv2 delete-target-group --target-group-arn "$tg" --region "$REGION"
+  done
+}
+
+# ── 4. RDS instance + leftover snapshots ────────────────────────────────────────
+kill_rds() {
+  say "[4] RDS — delete $RDS_ID"
+  if aws rds describe-db-instances --db-instance-identifier "$RDS_ID" --region "$REGION" >/dev/null 2>&1; then
+    if $TAKE_SNAPSHOT; then
+      run aws rds delete-db-instance --db-instance-identifier "$RDS_ID" \
+        --final-db-snapshot-identifier "listingjet-final-$DATESTAMP" --region "$REGION"
+      info "(final snapshot: listingjet-final-$DATESTAMP — delete it later once you're sure)"
+    else
+      run aws rds delete-db-instance --db-instance-identifier "$RDS_ID" \
+        --skip-final-snapshot --delete-automated-backups --region "$REGION"
+    fi
+  else
+    info "RDS instance not found — skipping."
+  fi
+  # old pre-migration safety-net snapshot still incurs storage charges
+  if aws rds describe-db-snapshots --db-snapshot-identifier "$OLD_SNAPSHOT" --region "$REGION" >/dev/null 2>&1; then
+    run aws rds delete-db-snapshot --db-snapshot-identifier "$OLD_SNAPSHOT" --region "$REGION"
+  fi
+}
+
+# ── 5. ElastiCache (Redis) ──────────────────────────────────────────────────────
+kill_elasticache() {
+  say "[5] ElastiCache — delete ListingJet Redis"
+  local rgs
+  rgs=$(aws elasticache describe-replication-groups --region "$REGION" \
+         --query 'ReplicationGroups[?contains(ReplicationGroupId,`listingjet`) || contains(Description,`istingJet`)].ReplicationGroupId' \
+         --output text 2>/dev/null)
+  for rg in $rgs; do
+    info "replication-group: $rg"
+    run aws elasticache delete-replication-group --replication-group-id "$rg" --region "$REGION"
+  done
+  local ccs
+  ccs=$(aws elasticache describe-cache-clusters --region "$REGION" \
+         --query 'CacheClusters[?contains(CacheClusterId,`listingjet`)].CacheClusterId' \
+         --output text 2>/dev/null)
+  for cc in $ccs; do
+    info "cache-cluster: $cc"
+    run aws elasticache delete-cache-cluster --cache-cluster-id "$cc" --region "$REGION"
+  done
+  [ -z "$rgs$ccs" ] && info "No ListingJet ElastiCache resources found."
+}
+
+# ── 6. CloudFront (disable then delete; deletion needs a 2nd pass) ──────────────
+kill_cloudfront() {
+  say "[6] CloudFront — disable ListingJet distributions"
+  local ids
+  ids=$(aws cloudfront list-distributions \
+         --query "DistributionList.Items[?contains(Comment,'listingjet') || contains(Comment,'ListingJet')].Id" \
+         --output text 2>/dev/null)
+  [ -z "$ids" ] && { info "No ListingJet CloudFront distributions found."; return; }
+  for id in $ids; do
+    info "distribution: $id"
+    if $EXECUTE; then
+      local etag cfg
+      etag=$(aws cloudfront get-distribution-config --id "$id" --query 'ETag' --output text)
+      cfg=$(aws cloudfront get-distribution-config --id "$id" --query 'DistributionConfig' --output json \
+            | python3 -c "import sys,json;c=json.load(sys.stdin);c['Enabled']=False;print(json.dumps(c))")
+      echo "$cfg" > "/tmp/cf-$id.json"
+      run aws cloudfront update-distribution --id "$id" --if-match "$etag" \
+        --distribution-config "file:///tmp/cf-$id.json"
+      info "  disabled. CloudFront takes ~10-15 min to deploy 'Disabled'."
+      info "  AFTER it shows Deployed+Disabled, delete with:"
+      info "    ETAG=\$(aws cloudfront get-distribution-config --id $id --query ETag --output text)"
+      info "    aws cloudfront delete-distribution --id $id --if-match \$ETAG"
+    else
+      info "DRY: would disable then (after deploy) delete distribution $id"
+    fi
+  done
+}
+
+# ── 7. S3, ECR, Secrets, CloudWatch logs ────────────────────────────────────────
+kill_storage_misc() {
+  say "[7a] S3 — empty + delete ListingJet media buckets"
+  local buckets
+  buckets=$(aws s3api list-buckets --query "Buckets[?starts_with(Name,'$S3_BUCKET_GLOB')].Name" --output text 2>/dev/null)
+  for b in $buckets; do
+    info "bucket: $b"
+    run aws s3 rm "s3://$b" --recursive --region "$REGION"
+    run aws s3api delete-bucket --bucket "$b" --region "$REGION"
+  done
+  [ -z "$buckets" ] && info "No matching buckets."
+
+  say "[7b] ECR — delete repos"
+  for r in "${ECR_REPOS[@]}"; do
+    if aws ecr describe-repositories --repository-names "$r" --region "$REGION" >/dev/null 2>&1; then
+      run aws ecr delete-repository --repository-name "$r" --force --region "$REGION"
+    fi
+  done
+
+  say "[7c] Secrets Manager — delete ListingJet secrets"
+  local secs
+  secs=$(aws secretsmanager list-secrets --region "$REGION" \
+          --query "SecretList[?contains(Name,'listingjet') || contains(Name,'ListingJet')].Name" \
+          --output text 2>/dev/null)
+  for s in $secs; do
+    info "secret: $s"
+    run aws secretsmanager delete-secret --secret-id "$s" --force-delete-without-recovery --region "$REGION"
+  done
+  [ -z "$secs" ] && info "No ListingJet secrets found."
+
+  say "[7d] CloudWatch — delete /listingjet/* log groups"
+  local lgs
+  lgs=$(aws logs describe-log-groups --log-group-name-prefix "/listingjet" --region "$REGION" \
+         --query 'logGroups[].logGroupName' --output text 2>/dev/null)
+  for lg in $lgs; do
+    run aws logs delete-log-group --log-group-name "$lg" --region "$REGION"
+  done
+  [ -z "$lgs" ] && info "No /listingjet log groups found."
+}
+
+# ── 8. Final billing-leftover scan (always runs, read-only) ─────────────────────
+scan_leftovers() {
+  say "[8] LEFTOVER SCAN — these silently keep billing if present"
+  info "Unattached Elastic IPs (release these):"
+  aws ec2 describe-addresses --region "$REGION" \
+    --query 'Addresses[?AssociationId==null].[AllocationId,PublicIp]' --output text 2>/dev/null | sed 's/^/    /'
+  if $EXECUTE; then
+    for alloc in $(aws ec2 describe-addresses --region "$REGION" \
+                    --query 'Addresses[?AssociationId==null].AllocationId' --output text 2>/dev/null); do
+      run aws ec2 release-address --allocation-id "$alloc" --region "$REGION"
+    done
+  fi
+  info "Available (orphan) EBS volumes:"
+  aws ec2 describe-volumes --region "$REGION" --filters Name=status,Values=available \
+    --query 'Volumes[].[VolumeId,Size]' --output text 2>/dev/null | sed 's/^/    /'
+  info "Manual RDS snapshots remaining:"
+  aws rds describe-db-snapshots --snapshot-type manual --region "$REGION" \
+    --query 'DBSnapshots[].DBSnapshotIdentifier' --output text 2>/dev/null | sed 's/^/    /'
+  info "EC2 snapshots owned by you:"
+  aws ec2 describe-snapshots --owner-ids self --region "$REGION" \
+    --query 'Snapshots[].[SnapshotId,VolumeSize]' --output text 2>/dev/null | sed 's/^/    /'
+  info "Remaining NAT gateways:"
+  aws ec2 describe-nat-gateways --region "$REGION" \
+    --filter Name=state,Values=available,pending \
+    --query 'NatGateways[].NatGatewayId' --output text 2>/dev/null | sed 's/^/    /'
+  say "Done. Check Billing → Cost Explorer tomorrow; it should trend to ~\$0."
+  info "Note: VPC/subnets/IGW themselves are free; leave them or delete the"
+  info "ListingJetNetwork CFN stack last if you want a spotless account."
+}
+
+# ── main ────────────────────────────────────────────────────────────────────────
+require_aws
+confirm
+prep_rds
+kill_ecs
+kill_nat
+kill_alb
+kill_rds
+kill_elasticache
+kill_cloudfront
+kill_storage_misc
+scan_leftovers


### PR DESCRIPTION
## Summary

Teardown tooling so the move off AWS can be **finished from a terminal that has AWS credentials** (this session doesn't). Pre-launch deployment, throwaway test data — the whole AWS footprint gets deleted to stop charges.

## Why a script and not `cdk destroy`
The CDK retains the stateful resources on purpose: RDS is `deletion_protection=True` + `removal_policy=RETAIN`, and the S3 media bucket is RETAIN (`infra/stacks/database.py:180`). A plain `cdk destroy` would **orphan the database and bucket and keep billing.** The script deletes them directly instead.

## What's here
- **`scripts/aws_decommission.sh`** — dry-run by default; requires `--execute` + a typed `DELETE` to act. Deletes in cost-priority order: ECS → NAT (+EIP) → ALB → RDS → ElastiCache → CloudFront → S3/ECR/Secrets/Logs. Discovers resource IDs dynamically and only touches things tagged/named for ListingJet. Ends with a **leftover-billing scan** (unattached EIPs, orphan EBS/snapshots, lingering NAT). `--no-snapshot` skips the final RDS snapshot.
- **`docs/runbooks/aws-decommission-plan.md`** — the step-by-step the local agent follows: dry-run → review → execute → CloudFront second pass (it can only be disabled synchronously) → re-run leftover scan → verify ~$0 in Cost Explorer → GitHub/repo cleanup.

## How it gets used
When home: `bash scripts/aws_decommission.sh` (review), then `bash scripts/aws_decommission.sh --execute`. The local Claude can run `docs/runbooks/aws-decommission-plan.md` directly.

## Verification
`bash -n` syntax-clean. The script is read-only unless `--execute` is passed, and is idempotent (tolerates already-deleted resources), so it's safe to dry-run anytime.

https://claude.ai/code/session_01QW8ZAsndUvQXMZPiEY4sXa

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW8ZAsndUvQXMZPiEY4sXa)_